### PR TITLE
Iron ox backend

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -58,6 +58,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arena"
 version = "0.0.0"
 dependencies = [
@@ -2129,6 +2137,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_codegen_ironox"
+version = "0.0.0"
+dependencies = [
+ "ar 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
@@ -3181,6 +3196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee94e9463ccb9d681e7b708082687b2c56d2bd420ca8a3d3157d27d59508ec0"
 "checksum ammonia 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd4c682378117e4186a492b2252b9537990e1617f44aed9788b9a1149de45477"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ar 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "095515608290b62ac2427084f9ac3cfeb5dc76067f7d94564db9db1c46cc0a85"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum assert_cli 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98589b0e465a6c510d95fceebd365bb79bedece7f6e18a480897f2015f85ec51"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "libstd",
   "libtest",
   "librustc_codegen_llvm",
+  "librustc_codegen_ironox",
   "tools/cargotest",
   "tools/clippy",
   "tools/compiletest",

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -536,13 +536,15 @@ pub fn rustc_cargo(builder: &Builder, cargo: &mut Command) {
 }
 
 pub fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
+    let backend = builder.config.rust_codegen_backends.get(0).cloned()
+        .unwrap_or(INTERNER.intern_str("llvm"));
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo.env("CFG_RELEASE", builder.rust_release())
          .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
          .env("CFG_VERSION", builder.rust_version())
          .env("CFG_PREFIX", builder.config.prefix.clone().unwrap_or_default())
-         .env("CFG_CODEGEN_BACKEND", &builder.config.rust_codegen_backends[0])
+         .env("CFG_CODEGEN_BACKEND", backend)
          .env("CFG_CODEGEN_BACKENDS_DIR", &builder.config.rust_codegen_backends_dir);
 
     let libdir_relative = builder.config.libdir_relative().unwrap_or(Path::new("lib"));

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -542,6 +542,7 @@ pub fn rustc_cargo_env(builder: &Builder, cargo: &mut Command) {
          .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
          .env("CFG_VERSION", builder.rust_version())
          .env("CFG_PREFIX", builder.config.prefix.clone().unwrap_or_default())
+         .env("CFG_CODEGEN_BACKEND", &builder.config.rust_codegen_backends[0])
          .env("CFG_CODEGEN_BACKENDS_DIR", &builder.config.rust_codegen_backends_dir);
 
     let libdir_relative = builder.config.libdir_relative().unwrap_or(Path::new("lib"));
@@ -657,11 +658,12 @@ impl Step for CodegenBackend {
         let out_dir = builder.cargo_out(compiler, Mode::Codegen, target);
 
         let mut cargo = builder.cargo(compiler, Mode::Codegen, target, "rustc");
-        cargo.arg("--manifest-path")
-            .arg(builder.src.join("src/librustc_codegen_llvm/Cargo.toml"));
+        cargo.arg("--manifest-path").arg(
+            builder.src.join(format!("src/librustc_codegen_{}/Cargo.toml", backend)));
         rustc_cargo_env(builder, &mut cargo);
 
-        let features = build_codegen_backend(&builder, &mut cargo, &compiler, target, backend);
+        let features = build_codegen_backend(
+            &builder, &mut cargo, &compiler, target, backend);
 
         let mut cargo_tails_args = vec![];
 
@@ -693,7 +695,8 @@ impl Step for CodegenBackend {
 
         let tmp_stamp = out_dir.join(".tmp.stamp");
 
-        let _folder = builder.fold_output(|| format!("stage{}-rustc_codegen_llvm", compiler.stage));
+        let _folder = builder.fold_output(
+            || format!("stage{}-rustc_codegen_{}", compiler.stage, backend));
         let files = run_cargo(builder,
                               cargo.arg("--features").arg(features),
                               cargo_tails_args,
@@ -702,10 +705,11 @@ impl Step for CodegenBackend {
         if builder.config.dry_run {
             return;
         }
+        let backend_identifier = &format!("rustc_codegen_{}-", backend)[..];
         let mut files = files.into_iter()
             .filter(|f| {
                 let filename = f.file_name().unwrap().to_str().unwrap();
-                is_dylib(filename) && filename.contains("rustc_codegen_llvm-")
+                is_dylib(filename) && filename.contains(backend_identifier)
             });
         let codegen_backend = match files.next() {
             Some(f) => f,
@@ -772,6 +776,9 @@ pub fn build_codegen_backend(builder: &Builder,
             if builder.config.llvm_link_shared {
                 cargo.env("LLVM_LINK_SHARED", "1");
             }
+        }
+        "ironox" => {
+            cargo.arg("--verbose");
         }
         _ => panic!("unknown backend: {}", backend),
     }

--- a/src/librustc_codegen_ironox/Cargo.toml
+++ b/src/librustc_codegen_ironox/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Gabriela Alexandra Moldovan"]
+authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>"]
 name = "rustc_codegen_ironox"
 version = "0.0.0"
 

--- a/src/librustc_codegen_ironox/Cargo.toml
+++ b/src/librustc_codegen_ironox/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["Gabriela Alexandra Moldovan"]
+name = "rustc_codegen_ironox"
+version = "0.0.0"
+
+[lib]
+name = "rustc_codegen_ironox"
+path = "lib.rs"
+crate-type = ["dylib"]
+test = false
+
+[dependencies]
+ar = "0.6.0"

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -104,10 +104,6 @@ impl CodegenBackend for IronOxCodegenBackend {
                     for bb in mir.basic_blocks() {
                         eprintln!("Statements: {:?}", bb.statements);
                     }
-                    if def_id.is_local() {
-                        let _ = inst.def.is_inline(tcx);
-                        let _ = tcx.codegen_fn_attrs(def_id);
-                    }
                 }
                 _ => {}
             }

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -1,0 +1,132 @@
+#![feature(box_syntax)]
+#![feature(optin_builtin_traits)]
+
+extern crate rustc;
+extern crate rustc_mir;
+extern crate rustc_target;
+#[macro_use]
+extern crate rustc_data_structures;
+extern crate rustc_codegen_utils;
+
+mod metadata;
+
+use std::any::Any;
+use std::sync::mpsc;
+
+use rustc::hir::def_id::LOCAL_CRATE;
+use rustc::dep_graph::DepGraph;
+use rustc::middle::cstore::MetadataLoader;
+use rustc::session::{CompileIncomplete, Session};
+use rustc::session::config::{OutputFilenames, PrintRequest};
+use rustc::ty::{self, TyCtxt};
+use rustc_codegen_utils::codegen_backend::CodegenBackend;
+use rustc_codegen_utils::target_features::{all_known_features, X86_WHITELIST};
+use rustc_data_structures::sync::Lrc;
+use rustc_mir::monomorphize::collector;
+use rustc_mir::monomorphize::item::MonoItem;
+
+mod back {
+    pub use rustc_codegen_utils::symbol_export;
+    pub use rustc_codegen_utils::symbol_names;
+}
+
+pub struct IronOxCodegenBackend(());
+
+impl !Send for IronOxCodegenBackend {}
+impl !Sync for IronOxCodegenBackend {}
+
+pub fn target_feature_whitelist(sess: &Session)
+    -> &'static [(&'static str, Option<&'static str>)] {
+    match &*sess.target.target.arch {
+        "x86" | "x86_64" => X86_WHITELIST,
+        _ => &[],
+    }
+}
+
+impl IronOxCodegenBackend {
+    pub fn new() -> Box<dyn CodegenBackend> {
+        box IronOxCodegenBackend(())
+    }
+}
+
+impl CodegenBackend for IronOxCodegenBackend {
+    fn init(&self, _sess: &Session) {}
+
+    fn print(&self, _req: PrintRequest, _sess: &Session) {}
+
+    fn print_passes(&self) {}
+
+    fn print_version(&self) {}
+
+    fn metadata_loader(&self) -> Box<dyn MetadataLoader + Sync> {
+        box metadata::IronOxMetadataLoader
+    }
+
+    fn provide(&self, providers: &mut ty::query::Providers) {
+        providers.target_features_whitelist = |tcx, cnum| {
+            assert_eq!(cnum, LOCAL_CRATE);
+            if tcx.sess.opts.actually_rustdoc {
+                Lrc::new(
+                    all_known_features()
+                        .map(|(a, b)| (a.to_string(), b.map(|s| s.to_string())))
+                        .collect(),
+                )
+            } else {
+                Lrc::new(
+                    target_feature_whitelist(tcx.sess)
+                        .iter()
+                        .map(|&(a, b)| (a.to_string(), b.map(|s| s.to_string())))
+                        .collect(),
+                )
+            }
+        };
+        back::symbol_names::provide(providers);
+        back::symbol_export::provide(providers);
+    }
+
+    fn provide_extern(&self, providers: &mut ty::query::Providers) {
+        back::symbol_export::provide_extern(providers);
+    }
+
+    fn codegen_crate<'a, 'tcx>(
+        &self,
+        tcx: TyCtxt<'a, 'tcx, 'tcx>,
+        _rx: mpsc::Receiver<Box<dyn Any + Send>>,
+    ) -> Box<dyn Any> {
+        // Print the MIR
+        for mono_item in collector::collect_crate_mono_items(
+            tcx, collector::MonoItemCollectionMode::Eager).0 {
+            match mono_item {
+                MonoItem::Fn(inst) => {
+                    let def_id = inst.def_id();
+                    eprintln!("Def ID: {:?}", def_id);
+                    let mir = tcx.instance_mir(inst.def);
+                    for bb in mir.basic_blocks() {
+                        eprintln!("Statements: {:?}", bb.statements);
+                    }
+                    if def_id.is_local() {
+                        let _ = inst.def.is_inline(tcx);
+                        let _ = tcx.codegen_fn_attrs(def_id);
+                    }
+                }
+                _ => {}
+            }
+        }
+        unimplemented!("codegen_crate");
+    }
+
+    fn join_codegen_and_link(
+        &self,
+        _ongoing_codegen: Box<dyn Any>,
+        _sess: &Session,
+        _dep_graph: &DepGraph,
+        _outputs: &OutputFilenames,
+    ) -> Result<(), CompileIncomplete> {
+        unimplemented!("join_codegen_and_link");
+    }
+}
+
+#[no_mangle]
+pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
+    IronOxCodegenBackend::new()
+}

--- a/src/librustc_codegen_ironox/metadata.rs
+++ b/src/librustc_codegen_ironox/metadata.rs
@@ -1,0 +1,25 @@
+extern crate ar;
+
+use rustc::middle::cstore::{MetadataLoader, METADATA_FILENAME};
+use rustc_data_structures::owning_ref::OwningRef;
+use rustc_target::spec::Target;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+pub use rustc_data_structures::sync::MetadataRef;
+
+pub struct IronOxMetadataLoader;
+
+impl MetadataLoader for IronOxMetadataLoader {
+    fn get_rlib_metadata(&self, _: &Target, filename: &Path)
+        -> Result<MetadataRef, String> {
+        unimplemented!("get_rlib_metadata {:?}", filename);
+    }
+
+    fn get_dylib_metadata(&self, _target: &Target, filename: &Path)
+        -> Result<MetadataRef, String> {
+        unimplemented!("get_dylib_metadata {:?}", filename);
+    }
+}

--- a/src/librustc_codegen_ironox/metadata.rs
+++ b/src/librustc_codegen_ironox/metadata.rs
@@ -15,7 +15,20 @@ pub struct IronOxMetadataLoader;
 impl MetadataLoader for IronOxMetadataLoader {
     fn get_rlib_metadata(&self, _: &Target, filename: &Path)
         -> Result<MetadataRef, String> {
-        unimplemented!("get_rlib_metadata {:?}", filename);
+        let input_file =
+            File::open(filename)
+                .map_err(|_e| format!("failed to read {}", filename.display()))?;
+        let mut archive = ar::Archive::new(input_file);
+        let mut buf = vec![];
+        while let Some(entry) = archive.next_entry() {
+            let mut entry = entry.expect("failed to parse archive entry");
+            if entry.header().identifier() == METADATA_FILENAME.to_string().as_bytes() {
+                entry.read_to_end(&mut buf).expect("failed to read metadata file");
+            }
+        }
+        let buf = OwningRef::new(box buf);
+        let buf: OwningRef<_, [u8]> = buf.map(|v| &v[..]);
+        Ok(rustc_erase_owner!(buf))
     }
 
     fn get_dylib_metadata(&self, _target: &Target, filename: &Path)

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -363,7 +363,11 @@ fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend> {
 
     let mut file: Option<PathBuf> = None;
 
-    let expected_name = format!("rustc_codegen_llvm-{}", backend_name);
+    let expected_name = if backend_name == "ironox" {
+        format!("rustc_codegen_{}-{}", backend_name, backend_name)
+    } else {
+        format!("rustc_codegen_llvm-{}", backend_name)
+    };
     for entry in d.filter_map(|e| e.ok()) {
         let path = entry.path();
         let filename = match path.file_name().and_then(|s| s.to_str()) {
@@ -1163,7 +1167,9 @@ pub fn version(binary: &str, matches: &getopts::Matches) {
         println!("commit-date: {}", unw(commit_date_str()));
         println!("host: {}", config::host_triple());
         println!("release: {}", unw(release_str()));
-        get_codegen_sysroot("llvm")().print_version();
+        let backend = option_env!("CFG_CODEGEN_BACKEND")
+            .map_or("llvm".to_string(), |s| s.to_string());
+        get_codegen_sysroot(&backend)().print_version();
     }
 }
 
@@ -1464,8 +1470,9 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     }
 
     if cg_flags.contains(&"passes=list".to_string()) {
-        get_codegen_sysroot("llvm")().print_passes();
-        return None;
+        let backend = &option_env!("CFG_CODEGEN_BACKEND")
+            .map_or("llvm".to_string(), |s| s.to_string())[..];
+        get_codegen_sysroot(backend)().print_passes();
     }
 
     if matches.opt_present("version") {

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -751,7 +751,8 @@ impl Default for TargetOptions {
             singlethread: false,
             no_builtins: false,
             i128_lowering: false,
-            codegen_backend: "llvm".to_string(),
+            codegen_backend: option_env!("CFG_CODEGEN_BACKEND")
+                .map_or("llvm".to_string(), |s| s.to_string()),
             default_hidden_visibility: false,
             embed_bitcode: false,
             emit_debug_gdb_scripts: true,


### PR DESCRIPTION
Please review #1 first.

This is the skeleton of the iron-ox backend. Currently, this backend only prints out the MIR and `panic!`s. 

This PR also contains the implementation of `get_rlib_metadata` in `IronOxMetadataLoader`.  `get_rlib_metadata` uses `ar` to extract the metadata out of archives (as opposed to using the LLVM archiver).