### PR TITLE
Dylib metadata

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -886,6 +886,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "graphviz"
 version = "0.0.0"
 
@@ -1550,6 +1560,11 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "polonius-engine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2156,7 @@ name = "rustc_codegen_ironox"
 version = "0.0.0"
 dependencies = [
  "ar 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2600,6 +2616,25 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scroll"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2824,16 @@ dependencies = [
 [[package]]
 name = "syn"
 version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3267,6 +3312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum git2-curl 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b502f6b1b467957403d168f0039e0c46fa6a1220efa2adaef25d5b267b5fe024"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e49edbcc9c7fc5beb8c0a54e7319ff8bed353a2b55e85811c6281188c2a6c84"
+"checksum goblin 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "f253a3ed1f04476c728f31871f8e338468a49f3fd396b174a91885908f77f19f"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum home 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "80dff82fb58cfbbc617fb9a9184b010be0529201553cda50ad04372bc2333aff"
@@ -3336,6 +3382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "05a079dd052e7b674d21cb31cbb6c05efd56a2cd2827db7692e2f1a507ebd998"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "104630aa1c83213cbc76db0703630fcb0421dac3585063be4ce9a8a2feeaa745"
+"checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum polonius-engine 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b6b0a7f5f4278b991ffd14abce1d01b013121ad297460237ef0a2f08d43201"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
@@ -3388,6 +3435,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum schannel 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "dc1fabf2a7b6483a141426e1afd09ad543520a77ac49bd03c286e7696ccfd77f"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
+"checksum scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.75 (registry+https://github.com/rust-lang/crates.io-index)" = "22d340507cea0b7e6632900a176101fea959c7065d93ba555072da90aaaafc87"
@@ -3409,6 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
+"checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum tar 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "e8f41ca4a5689f06998f0247fcb60da6c760f1950cc9df2a10d71575ad0b062a"

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -42,6 +42,28 @@ pub use self::NativeLibraryKind::*;
 
 pub const METADATA_FILENAME: &str = "rust.metadata.bin";
 
+pub fn metadata_section_name(target: &Target) -> &'static str {
+    // Historical note:
+    //
+    // When using link.exe it was seen that the section name `.note.rustc`
+    // was getting shortened to `.note.ru`, and according to the PE and COFF
+    // specification:
+    //
+    // > Executable images do not use a string table and do not support
+    // > section names longer than 8 characters
+    //
+    // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
+    //
+    // As a result, we choose a slightly shorter name! As to why
+    // `.note.rustc` works on MinGW, that's another good question...
+
+    if target.options.is_like_osx {
+        "__DATA,.rustc"
+    } else {
+        ".rustc"
+    }
+}
+
 // lonely orphan structs and enums looking for a better home
 
 /// Where a crate came from on the local filesystem. One of these three options

--- a/src/librustc_codegen_ironox/Cargo.toml
+++ b/src/librustc_codegen_ironox/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["dylib"]
 test = false
 
 [dependencies]
-ar = "0.6.0"
+ar = "0.6"
+goblin = "0.0"

--- a/src/librustc_codegen_ironox/base.rs
+++ b/src/librustc_codegen_ironox/base.rs
@@ -1,0 +1,23 @@
+use rustc::middle::cstore::EncodedMetadata;
+use rustc::session::config::OutputFilenames;
+use rustc::ty::TyCtxt;
+use rustc_data_structures::svh::Svh;
+use syntax_pos::symbol::Symbol;
+
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::mpsc;
+
+#[allow(dead_code)]
+pub struct OngoingCodegen {
+    crate_name: Symbol,
+    crate_hash: Svh,
+    metadata: EncodedMetadata,
+    output_filenames: Arc<OutputFilenames>,
+}
+
+pub fn codegen_crate<'a, 'tcx>(_tcx: TyCtxt<'a, 'tcx, 'tcx>,
+                               _rx: mpsc::Receiver<Box<dyn Any + Send>>)
+                               -> OngoingCodegen {
+    unimplemented!("base::codegen_crate");
+}

--- a/src/librustc_codegen_ironox/metadata.rs
+++ b/src/librustc_codegen_ironox/metadata.rs
@@ -1,4 +1,5 @@
 extern crate ar;
+extern crate goblin;
 
 use rustc::middle::cstore::{MetadataLoader, METADATA_FILENAME};
 use rustc_data_structures::owning_ref::OwningRef;
@@ -15,9 +16,8 @@ pub struct IronOxMetadataLoader;
 impl MetadataLoader for IronOxMetadataLoader {
     fn get_rlib_metadata(&self, _: &Target, filename: &Path)
         -> Result<MetadataRef, String> {
-        let input_file =
-            File::open(filename)
-                .map_err(|_e| format!("failed to read {}", filename.display()))?;
+        let input_file = File::open(filename)
+            .map_err(|_e| format!("failed to read {}", filename.display()))?;
         let mut archive = ar::Archive::new(input_file);
         let mut buf = vec![];
         while let Some(entry) = archive.next_entry() {
@@ -33,6 +33,27 @@ impl MetadataLoader for IronOxMetadataLoader {
 
     fn get_dylib_metadata(&self, _target: &Target, filename: &Path)
         -> Result<MetadataRef, String> {
-        unimplemented!("get_dylib_metadata {:?}", filename);
+        let mut input_file = File::open(filename)
+            .map_err(|_e| format!("failed to read {}", filename.display()))?;
+        let mut buf = vec![];
+        input_file.read_to_end(&mut buf)
+            .map_err(|_| format!("failed to read {}", filename.display()))?;
+        let buf = OwningRef::new(box buf);
+        let buf = buf.try_map(|buf| search_meta_section(&buf, filename))?;
+        return Ok(rustc_erase_owner!(buf));
     }
+}
+
+fn search_meta_section<'a>(bytes: &'a [u8], filename: &Path)
+    -> Result<&'a [u8], String> {
+    let elf = goblin::elf::Elf::parse(&bytes).map_err(|_| "failed to parse ELF")?;
+    for sh in &elf.section_headers {
+        if elf.shdr_strtab.get(sh.sh_name)
+            .map_or(false, |r| r.expect("") == ".rustc") {
+            let start_index = sh.sh_offset as usize;
+            let end_index = (sh.sh_offset + sh.sh_size) as usize;
+            return Ok(&bytes[start_index..end_index]);
+        }
+    }
+    Err(format!("metadata not found: '{}'", filename.display()))
 }

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::cstore::MetadataLoader;
+use rustc::middle::cstore::{MetadataLoader, METADATA_FILENAME};
 use rustc_target::spec::Target;
 use llvm;
 use llvm::{False, ObjectFile, mk_section_iter};
@@ -21,7 +21,6 @@ use std::slice;
 use rustc_fs_util::path2cstr;
 
 pub use rustc_data_structures::sync::MetadataRef;
-pub use rustc::middle::cstore::METADATA_FILENAME;
 
 pub struct LlvmMetadataLoader;
 
@@ -92,28 +91,6 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
         }
     }
     Err(format!("metadata not found: '{}'", filename.display()))
-}
-
-pub fn metadata_section_name(target: &Target) -> &'static str {
-    // Historical note:
-    //
-    // When using link.exe it was seen that the section name `.note.rustc`
-    // was getting shortened to `.note.ru`, and according to the PE and COFF
-    // specification:
-    //
-    // > Executable images do not use a string table and do not support
-    // > section names longer than 8 characters
-    //
-    // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
-    //
-    // As a result, we choose a slightly shorter name! As to why
-    // `.note.rustc` works on MinGW, that's another good question...
-
-    if target.options.is_like_osx {
-        "__DATA,.rustc"
-    } else {
-        ".rustc"
-    }
 }
 
 fn read_metadata_section_name(_target: &Target) -> &'static str {


### PR DESCRIPTION
`IronOxMetadataLoader` can now extract metadata from shared libs. The loader:
* uses goblin to parse the ELF
* extracts the contents of the ".rustc" section, which contains the metadata

The `search_meta_section` function returns the metadata, which is a slice of the raw ELF (received as input).