### PR TITLE
Fix broken imports.

### DIFF
--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -31,7 +31,6 @@ use super::CachedModuleCodegen;
 use abi;
 use back::write::{self, OngoingCodegen};
 use llvm::{self, TypeKind, get_param};
-use metadata;
 use rustc::dep_graph::cgu_reuse_tracker::CguReuse;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::middle::lang_items::StartFnLangItem;
@@ -656,7 +655,7 @@ fn write_metadata<'a, 'gcx>(tcx: TyCtxt<'a, 'gcx, 'gcx>,
     };
     unsafe {
         llvm::LLVMSetInitializer(llglobal, llconst);
-        let section_name = metadata::metadata_section_name(&tcx.sess.target.target);
+        let section_name = cstore::metadata_section_name(&tcx.sess.target.target);
         let name = SmallCStr::new(section_name);
         llvm::LLVMSetSection(llglobal, name.as_ptr());
 

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use rustc::middle::cstore::{MetadataLoader, METADATA_FILENAME};
+use rustc::middle::cstore::MetadataLoader;
 use rustc_target::spec::Target;
 use llvm;
 use llvm::{False, ObjectFile, mk_section_iter};
@@ -20,6 +20,7 @@ use std::ptr;
 use std::slice;
 use rustc_fs_util::path2cstr;
 
+pub use rustc::middle::cstore::METADATA_FILENAME;
 pub use rustc_data_structures::sync::MetadataRef;
 
 pub struct LlvmMetadataLoader;


### PR DESCRIPTION
My previous PR broke the LLVM backend. `pub use rustc::middle::cstore::METADATA_FILENAME;` in `metadata.rs` *has* to stay `pub` (it's required by a file that uses `metadata.rs`. 

I'm planning on setting up tests to make sure this doesn't happen again.