### PR TITLE
Set up bors.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./x.py clean
+RUST_BACKTRACE=1 ./x.py check --config .buildbot.toml

--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -1,0 +1,4 @@
+# Config file for continuous integration.
+
+[rust]
+codegen-backends = ["ironox"]

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+# The service providing the commit statuses to GitHub.
+status = [
+  "buildbot/buildbot-build-script"
+]
+
+# Allow two hours for builds.
+timeout_sec = 7200
+
+# Have bors delete auto-merged branches
+delete_merged_branches = true


### PR DESCRIPTION
This hopefully enables bors.

The build will fail, because the `ironox` backend in its current form cannot build `rustc`.  