### PR TITLE
Add new x86 target features.

### DIFF
--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -19,8 +19,9 @@ use rustc_codegen_ssa::base::maybe_create_entry_wrapper;
 use super::LlvmCodegenBackend;
 
 use llvm;
+use metadata;
 use rustc::mir::mono::{Linkage, Visibility, Stats};
-use rustc::middle::cstore::{self, EncodedMetadata};
+use rustc::middle::cstore::{EncodedMetadata};
 use rustc::ty::TyCtxt;
 use rustc::middle::exported_symbols;
 use rustc::session::config::{self, DebugInfo};
@@ -95,7 +96,7 @@ pub fn write_metadata<'a, 'gcx>(
     };
     unsafe {
         llvm::LLVMSetInitializer(llglobal, llconst);
-        let section_name = cstore::metadata_section_name(&tcx.sess.target.target);
+        let section_name = metadata::metadata_section_name(&tcx.sess.target.target);
         let name = SmallCStr::new(section_name);
         llvm::LLVMSetSection(llglobal, name.as_ptr());
 

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -10,8 +10,9 @@ use std::ptr;
 use std::slice;
 use rustc_fs_util::path_to_c_string;
 
-pub use rustc::middle::cstore::METADATA_FILENAME;
 pub use rustc_data_structures::sync::MetadataRef;
+
+pub const METADATA_FILENAME: &str = "rust.metadata.bin";
 
 pub struct LlvmMetadataLoader;
 
@@ -82,6 +83,28 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
         }
     }
     Err(format!("metadata not found: '{}'", filename.display()))
+}
+
+pub fn metadata_section_name(target: &Target) -> &'static str {
+    // Historical note:
+    //
+    // When using link.exe it was seen that the section name `.note.rustc`
+    // was getting shortened to `.note.ru`, and according to the PE and COFF
+    // specification:
+    //
+    // > Executable images do not use a string table and do not support
+    // > section names longer than 8 characters
+    //
+    // https://msdn.microsoft.com/en-us/library/windows/hardware/gg463119.aspx
+    //
+    // As a result, we choose a slightly shorter name! As to why
+    // `.note.rustc` works on MinGW, that's another good question...
+
+    if target.options.is_like_osx {
+        "__DATA,.rustc"
+    } else {
+        ".rustc"
+    }
 }
 
 fn read_metadata_section_name(_target: &Target) -> &'static str {

--- a/src/librustc_codegen_utils/target_features.rs
+++ b/src/librustc_codegen_utils/target_features.rs
@@ -35,6 +35,7 @@ pub const AARCH64_WHITELIST: &[(&str, Option<&str>)] = &[
 ];
 
 pub const X86_WHITELIST: &[(&str, Option<&str>)] = &[
+    ("adx", Some("adx_target_feature")),
     ("aes", None),
     ("avx", None),
     ("avx2", None),
@@ -50,6 +51,7 @@ pub const X86_WHITELIST: &[(&str, Option<&str>)] = &[
     ("avx512vpopcntdq", Some("avx512_target_feature")),
     ("bmi1", None),
     ("bmi2", None),
+    ("cmpxchg16b", Some("cmpxchg16b_target_feature")),
     ("fma", None),
     ("fxsr", None),
     ("lzcnt", None),


### PR DESCRIPTION
The changes in `metadata.rs` and `base.rs` should've been introduced in the sync PR.

Two new target features were added in `src/librustc_codegen/llvm/llvm_util.rs`. `src/librustc_codegen_utils/target_features.rs` duplicates this code, because I don't want the ironox backend to depend on the llvm_util.rs for the feature list. The `all_known_features` function is used [here](https://github.com/gabi-250/rust/blob/master/src/librustc_codegen_ironox/lib.rs#L284) (when building the docs, all target features are whitelisted). I will likely come up with a better solution in a future PR.