### PR TITLE
IronOxModule internal representation

### DIFF
--- a/.buildbot-ironox.toml
+++ b/.buildbot-ironox.toml
@@ -1,0 +1,2 @@
+[rust]
+codegen-backends = ["ironox"]

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -8,3 +8,6 @@ git clean -dffx # If upstream removes a submodule, remove the files from disk.
 # Note that the gdb must be Python enabled.
 PATH=/opt/gdb-8.2/bin:${PATH} RUST_BACKTRACE=1 \
 ./x.py test --config .buildbot.toml
+
+# Make sure there are no compile errors
+RUST_BACKTRACE=1 ./x.py check --config .buildbot-ironox.toml

--- a/src/librustc_codegen_ironox/abi.rs
+++ b/src/librustc_codegen_ironox/abi.rs
@@ -25,7 +25,7 @@ impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn apply_attrs_callsite(
         &mut self,
         ty: &FnType<'tcx, Ty<'tcx>>,
-        callsite: &'ll Value
+        callsite: Value
     ) {
         unimplemented!("apply_attrs_callsite");
     }
@@ -36,7 +36,7 @@ impl ArgTypeMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         ty: &ArgType<'tcx, Ty<'tcx>>,
         idx: &mut usize,
-        dst: PlaceRef<'tcx, &'ll Value>
+        dst: PlaceRef<'tcx, Value>
     ) {
         unimplemented!("store_fn_arg");
     }
@@ -44,13 +44,13 @@ impl ArgTypeMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn store_arg_ty(
         &mut self,
         ty: &ArgType<'tcx, Ty<'tcx>>,
-        val: &'ll Value,
-        dst: PlaceRef<'tcx, &'ll Value>
+        val: Value,
+        dst: PlaceRef<'tcx, Value>
     ) {
         unimplemented!("store_arg_ty");
     }
 
-    fn memory_ty(&self, ty: &ArgType<'tcx, Ty<'tcx>>) -> &'ll Type {
+    fn memory_ty(&self, ty: &ArgType<'tcx, Ty<'tcx>>) -> Type {
         unimplemented!("memory_ty");
     }
 }

--- a/src/librustc_codegen_ironox/asm.rs
+++ b/src/librustc_codegen_ironox/asm.rs
@@ -20,8 +20,8 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn codegen_inline_asm(
         &mut self,
         ia: &hir::InlineAsm,
-        outputs: Vec<PlaceRef<'tcx, &'ll Value>>,
-        inputs: Vec<&'ll Value>
+        outputs: Vec<PlaceRef<'tcx, Value>>,
+        inputs: Vec<Value>
     ) -> bool {
         unimplemented!("codegen_inline_asm");
     }

--- a/src/librustc_codegen_ironox/base.rs
+++ b/src/librustc_codegen_ironox/base.rs
@@ -43,9 +43,9 @@ fn codegen_ironox_module<'ll, 'tcx>(
 ) -> (Stats, ModuleCodegen<ModuleIronOx>) {
     let backend = IronOxCodegenBackend(());
     let cgu = tcx.codegen_unit(cgu_name);
-    let ironox_module = backend.new_metadata(tcx.sess, &cgu_name.as_str());
+    let mut ironox_module = backend.new_metadata(tcx.sess, &cgu_name.as_str());
     let stats = {
-        let cx = CodegenCx::new(tcx, cgu, &ironox_module);
+        let cx = CodegenCx::new(tcx, cgu, &mut ironox_module);
         let mono_items = cx.codegen_unit
                            .items_in_deterministic_order(cx.tcx);
         for &(mono_item, (linkage, visibility)) in &mono_items {

--- a/src/librustc_codegen_ironox/basic_block.rs
+++ b/src/librustc_codegen_ironox/basic_block.rs
@@ -6,5 +6,52 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use context::CodegenCx;
+use value::Value;
+
+macro_rules! asm {
+    ($m:expr, $($args:expr)*) => {
+        $(
+            $m.instrs.push(format!("{}\n", $args));
+        )*
+    }
+}
+
+/// The index of the parent function, and the index of the basic block
+/// in the function.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct BasicBlock(pub usize, pub usize);
+
+/// A basic block.
 #[derive(Debug, PartialEq)]
-pub struct BasicBlock {}
+pub struct BasicBlockData {
+    /// The label of the basic block.
+    pub label: String,
+    /// The x86-64 instructions in this basic block.
+    pub instrs: Vec<String>,
+    /// The function the basic block belongs to.
+    pub parent: Value,
+    /// The terminator of the basic block.
+    pub terminator: Option<String>,
+}
+
+impl BasicBlockData {
+    pub fn new(cx: &CodegenCx, label: &str, parent: Value) -> BasicBlock {
+        let mut bb = BasicBlockData {
+            label: label.to_string(),
+            instrs: vec![],
+            parent: parent,
+            terminator: None,
+        };
+        asm!(bb,
+             format!("{}:", label));
+        let parent = match parent {
+            Value::Function(p) => p,
+            _ => bug!("The parent of a basic block has to be a function")
+        };
+        // the new basic block is the child of the specified `parent`
+        // basic block
+        let bb_index = cx.module.borrow_mut().functions[parent].add_bb(bb);
+        BasicBlock(parent, bb_index)
+    }
+}

--- a/src/librustc_codegen_ironox/builder.rs
+++ b/src/librustc_codegen_ironox/builder.rs
@@ -8,10 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use rustc_codegen_ssa::base::to_immediate;
 use rustc_codegen_ssa::common::{IntPredicate, RealPredicate, AtomicOrdering,
     SynchronizationScope, AtomicRmwBinOp};
 use rustc_codegen_ssa::MemFlags;
-use rustc_codegen_ssa::mir::operand::OperandRef;
+use rustc_codegen_ssa::mir::operand::{OperandValue, OperandRef};
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use context::CodegenCx;
 use value::Value;
@@ -20,11 +21,12 @@ use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::layout::{Align, Size, TyLayout};
 use rustc_codegen_ssa::traits::*;
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::ffi::CStr;
 use std::ops::{Deref, Range};
 use syntax;
 
-use basic_block::BasicBlock;
+use basic_block::{BasicBlock, BasicBlockData};
 use ironox_type::Type;
 
 impl BackendTypes for Builder<'_, 'll, 'tcx> {
@@ -74,8 +76,14 @@ impl HasCodegen<'tcx> for Builder<'a, 'll, 'tcx> {
 }
 
 impl StaticBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
-    fn get_static(&self, def_id: DefId) -> &'ll Value {
+    fn get_static(&self, def_id: DefId) -> Value {
         unimplemented!("get_static");
+    }
+}
+
+impl Builder<'a, 'll, 'tcx> {
+    fn emit_instr(&mut self, asm: String) {
+        unimplemented!("emit_instr");
     }
 }
 
@@ -84,23 +92,25 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         oop: OverflowOp,
         ty: Ty,
-        lhs: &'ll Value,
-        rhs: &'ll Value,
-    ) -> (&'ll Value, &'ll Value) {
+        lhs: Value,
+        rhs: Value,
+    ) -> (Value, Value) {
         unimplemented!("checked_binop");
     }
 
     fn new_block<'b>(
         cx: &'a Self::CodegenCx,
-        llfn: <Self::CodegenCx as BackendTypes>::Value,
+        llfn: Value,
         name: &'b str
     )-> Self {
-        let bx = Builder::with_cx(cx);
-        // add a basic block
+        let mut bx = Builder::with_cx(cx);
+        let bb = BasicBlockData::new(cx, name, llfn);
+        bx.position_at_end(bb);
         bx
     }
 
     fn with_cx(cx: &'a Self::CodegenCx) -> Self {
+        // FIXME? this is an invalid position and must be overwritten
         Builder {
             cx,
         }
@@ -109,374 +119,384 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn build_sibling_block<'b>(&self, name: &'b str) -> Self {
         Builder::new_block(self.cx, self.llfn(), name)
     }
+
     fn cx(&self) -> &CodegenCx<'ll, 'tcx> {
         &self.cx
     }
 
-    fn llfn(&self) -> &'ll Value {
-        &Value {}
+    fn llfn(&self) -> Value {
+        unimplemented!("llfn");
     }
 
-    fn llbb(&self) -> &'ll BasicBlock {
-        &BasicBlock {}
+    fn llbb(&self) -> BasicBlock {
+        unimplemented!("llbb");
     }
 
     fn count_insn(&self, category: &str) {
         unimplemented!("count_insn");
     }
 
-    fn set_value_name(&mut self, value: <Self::CodegenCx as BackendTypes>::Value, name: &str) {
-        unimplemented!("set_value_name");
+    fn set_value_name(&mut self, value: Value, name: &str) {
+        // FIXME: rename the value
     }
 
-    fn position_at_end(&mut self, llbb: <Self::CodegenCx as BackendTypes>::BasicBlock) {
-        unimplemented!("position_at_end");
+    fn position_at_end(&mut self, llbb: BasicBlock) {
+        let llfn = llbb.0;
+        let llbb = llbb.1;
+        let instr =
+            self.cx.module.borrow().functions[llfn].basic_blocks[llbb].instrs.len();
     }
 
-    fn position_at_start(&mut self, llbb: <Self::CodegenCx as BackendTypes>::BasicBlock) {
+    fn position_at_start(&mut self, llbb: BasicBlock) {
         unimplemented!("position_at_start");
     }
 
     fn ret_void(&mut self) {
-        unimplemented!("ret_void");
+        self.emit_instr("ret".to_string());
     }
 
-    fn ret(&mut self, v: <Self::CodegenCx as BackendTypes>::Value) {
-        unimplemented!("ret");
+    fn ret(&mut self, v: Value) {
+        // FIXME: add a return instruction at the current builder position
     }
 
-    fn br(&mut self, dest: <Self::CodegenCx as BackendTypes>::BasicBlock) {
-        unimplemented!("br");
+    fn br(&mut self, dest: BasicBlock) {
+        let br_instr = {
+            let module = self.cx.module.borrow();
+            format!(
+                "jmp {}",
+                module.functions[dest.0].basic_blocks[dest.1].label)
+        };
+        self.emit_instr(br_instr);
     }
 
     fn cond_br(
         &mut self,
-        cond: <Self::CodegenCx as BackendTypes>::Value,
-        then_llbb: <Self::CodegenCx as BackendTypes>::BasicBlock,
-        else_llbb: <Self::CodegenCx as BackendTypes>::BasicBlock,
+        cond: Value,
+        then_llbb: BasicBlock,
+        else_llbb: BasicBlock,
     ) {
         unimplemented!("cond_br");
     }
 
     fn switch(
         &mut self,
-        v: <Self::CodegenCx as BackendTypes>::Value,
-        else_llbb: <Self::CodegenCx as BackendTypes>::BasicBlock,
+        v: Value,
+        else_llbb: BasicBlock,
         num_cases: usize,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("switch");
     }
 
     fn invoke(
         &mut self,
-        llfn: <Self::CodegenCx as BackendTypes>::Value,
-        args: &[<Self::CodegenCx as BackendTypes>::Value],
-        then: <Self::CodegenCx as BackendTypes>::BasicBlock,
-        catch: <Self::CodegenCx as BackendTypes>::BasicBlock,
+        llfn: Value,
+        args: &[Value],
+        then: BasicBlock,
+        catch: BasicBlock,
         funclet: Option<&Self::Funclet>,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("invoke");
     }
 
     fn unreachable(&mut self) {
-        unimplemented!("unreachable");
+        // FIXME?
     }
 
     fn add(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("add");
     }
 
     fn fadd(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fadd");
     }
 
     fn fadd_fast(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fadd_fast");
     }
 
     fn sub(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("sub");
     }
 
     fn fsub(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fsub");
     }
 
     fn fsub_fast(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fsub_fast");
     }
 
     fn mul(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("mul");
     }
 
     fn fmul(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fmul");
     }
 
     fn fmul_fast(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fmul_fast");
     }
 
     fn udiv(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("udiv");
     }
 
     fn exactudiv(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("exactudiv");
     }
 
     fn sdiv(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("sdiv");
     }
 
     fn exactsdiv(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("exactsdiv");
     }
 
     fn fdiv(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fdiv");
     }
 
     fn fdiv_fast(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("fdiv_fast");
     }
 
     fn urem(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("urem");
     }
 
     fn srem(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("srem");
     }
 
     fn frem(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("frem");
     }
 
     fn frem_fast(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("frem_fast");
     }
 
     fn shl(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("shl");
     }
 
     fn lshr(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("lshr");
     }
 
     fn ashr(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("ashr");
     }
 
     fn and(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("and");
     }
 
     fn or(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("or");
     }
 
     fn xor(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("xor");
     }
 
     fn neg(
         &mut self,
-        v: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        v: Value
+    )-> Value {
         unimplemented!("neg");
     }
 
     fn fneg(
         &mut self,
-        v: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        v: Value
+    )-> Value {
         unimplemented!("fneg");
     }
 
     fn not(
         &mut self,
-        v: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        v: Value
+    )-> Value {
         unimplemented!("not");
     }
 
     fn alloca(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type,
+        ty: Type,
         name: &str, align: Align
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("alloca");
     }
 
     fn dynamic_alloca(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type,
+        ty: Type,
         name: &str, align: Align
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("dynamic_alloca");
     }
 
     fn array_alloca(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type,
-        len: <Self::CodegenCx as BackendTypes>::Value,
+        ty: Type,
+        len: Value,
         name: &str,
         align: Align
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("array_alloca");
     }
 
     fn load(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        ptr: Value,
         align: Align
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("load");
     }
 
     fn volatile_load(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        ptr: Value
+    )-> Value {
         unimplemented!("volatile_load");
     }
 
     fn atomic_load(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        ptr: Value,
         order: AtomicOrdering, size: Size
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("atomic_load");
     }
 
     fn range_metadata(
         &mut self,
-        load: <Self::CodegenCx as BackendTypes>::Value,
+        load: Value,
         range: Range<u128>
     ) {
         unimplemented!("range_metadata");
     }
 
-    fn nonnull_metadata(&mut self, load: <Self::CodegenCx as BackendTypes>::Value) {
+    fn nonnull_metadata(&mut self, load: Value) {
         unimplemented!("nonnull_metadata");
     }
 
     fn store(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        val: Value,
+        ptr: Value,
         align: Align
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("store");
     }
 
     fn atomic_store(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        val: Value,
+        ptr: Value,
         order: AtomicOrdering,
         size: Size
     ) {
@@ -485,170 +505,172 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
     fn store_with_flags(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        val: Value,
+        ptr: Value,
         align: Align,
         flags: MemFlags,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("store_with_flags");
+    )-> Value {
+        ptr
     }
 
     fn gep(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
-        indices: &[<Self::CodegenCx as BackendTypes>::Value]
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        ptr: Value,
+        indices: &[Value]
+    )-> Value {
         unimplemented!("gep");
     }
 
     fn inbounds_gep(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
-        indices: &[<Self::CodegenCx as BackendTypes>::Value]
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        ptr: Value,
+        indices: &[Value]
+    )-> Value {
         unimplemented!("inbounds_gep");
     }
 
     fn struct_gep(
         &mut self,
-        ptr: <Self::CodegenCx as BackendTypes>::Value,
+        ptr: Value,
         idx: u64
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("struct_gep");
     }
 
     fn trunc(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("trunc");
     }
 
     fn sext(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("sext");
     }
 
     fn fptoui(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("fptoui");
     }
 
     fn fptosi(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("fptosi");
     }
 
     fn uitofp(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("uitofp");
     }
 
     fn sitofp(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("sitofp");
     }
 
     fn fptrunc(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("fptrunc");
     }
 
     fn fpext(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("fpext");
     }
 
     fn ptrtoint(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("ptrtoint");
     }
 
     fn inttoptr(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("inttoptr");
     }
 
     fn bitcast(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("bitcast");
     }
 
     fn intcast(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type, is_signed: bool
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("intcast");
+        val: Value,
+        dest_ty: Type,
+        is_signed: bool
+    )-> Value {
+        val
     }
 
     fn pointercast(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("pointercast");
+        val: Value,
+        dest_ty: Type
+    )-> Value {
+        // FIXME? nothing to do
+        val
     }
 
     fn icmp(
         &mut self,
         op: IntPredicate,
-        lhs: <Self::CodegenCx as BackendTypes>::Value, rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value, rhs: Value
+    )-> Value {
         unimplemented!("icmp");
     }
 
     fn fcmp(
         &mut self,
         op: RealPredicate,
-        lhs: <Self::CodegenCx as BackendTypes>::Value, rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value, rhs: Value
+    )-> Value {
         unimplemented!("fcmp");
     }
 
     fn empty_phi(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type)-> <Self::CodegenCx as BackendTypes>::Value {
+        ty: Type)-> Value {
         unimplemented!("empty_phi");
     }
 
     fn phi(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type,
-        vals: &[<Self::CodegenCx as BackendTypes>::Value],
-        bbs: &[<Self::CodegenCx as BackendTypes>::BasicBlock]
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        ty: Type,
+        vals: &[Value],
+        bbs: &[BasicBlock]
+    )-> Value {
         unimplemented!("phi");
     }
 
@@ -656,223 +678,224 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         asm: &CStr,
         cons: &CStr,
-        inputs: &[&'ll Value], output: &'ll Type,
+        inputs: &[Value], output: Type,
         volatile: bool, alignstack: bool,
-        dia: syntax::ast::AsmDialect) -> Option<&'ll Value> {
+        dia: syntax::ast::AsmDialect) -> Option<Value> {
         unimplemented!("inline_asm_call");
     }
 
     fn minnum(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("minnum");
     }
 
     fn maxnum(
         &mut self,
-        lhs: <Self::CodegenCx as BackendTypes>::Value,
-        rhs: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        lhs: Value,
+        rhs: Value
+    )-> Value {
         unimplemented!("maxnum");
     }
 
     fn select(
-        &mut self, cond: <Self::CodegenCx as BackendTypes>::Value,
-        then_val: <Self::CodegenCx as BackendTypes>::Value,
-        else_val: <Self::CodegenCx as BackendTypes>::Value,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        &mut self, cond: Value,
+        then_val: Value,
+        else_val: Value,
+    )-> Value {
         unimplemented!("select");
     }
 
     fn va_arg(
         &mut self,
-        list: <Self::CodegenCx as BackendTypes>::Value,
-        ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        list: Value,
+        ty: Type
+    )-> Value {
         unimplemented!("va_arg");
     }
 
     fn extract_element(&mut self,
-        vec: <Self::CodegenCx as BackendTypes>::Value,
-        idx: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        vec: Value,
+        idx: Value
+    )-> Value {
         unimplemented!("extract_element");
     }
 
     fn insert_element(
-        &mut self, vec: <Self::CodegenCx as BackendTypes>::Value,
-        elt: <Self::CodegenCx as BackendTypes>::Value,
-        idx: <Self::CodegenCx as BackendTypes>::Value,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        &mut self, vec: Value,
+        elt: Value,
+        idx: Value,
+    )-> Value {
         unimplemented!("insert_element");
     }
 
     fn shuffle_vector(
         &mut self,
-        v1: <Self::CodegenCx as BackendTypes>::Value,
-        v2: <Self::CodegenCx as BackendTypes>::Value,
-        mask: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        v1: Value,
+        v2: Value,
+        mask: Value
+    )-> Value {
         unimplemented!("shuffle_vector");
     }
 
     fn vector_splat(
         &mut self,
         num_elts: usize,
-        elt: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        elt: Value
+    )-> Value {
         unimplemented!("vector_splat");
     }
 
     fn vector_reduce_fadd_fast(
         &mut self,
-        acc: <Self::CodegenCx as BackendTypes>::Value,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        acc: Value,
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fadd_fast");
     }
 
     fn vector_reduce_fmul_fast(
         &mut self,
-        acc: <Self::CodegenCx as BackendTypes>::Value,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        acc: Value,
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fmul_fast");
     }
 
     fn vector_reduce_add(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_add");
     }
 
     fn vector_reduce_mul(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_mul");
     }
 
     fn vector_reduce_and(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_and");
     }
 
     fn vector_reduce_or(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_or");
     }
 
     fn vector_reduce_xor(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_xor");
     }
 
     fn vector_reduce_fmin(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fmin");
     }
 
     fn vector_reduce_fmax(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fmax");
     }
 
     fn vector_reduce_fmin_fast(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fmin_fast");
     }
 
     fn vector_reduce_fmax_fast(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        src: Value
+    )-> Value {
         unimplemented!("vector_reduce_fmax_fast");
     }
 
     fn vector_reduce_min(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value,
+        src: Value,
         is_signed: bool
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("vector_reduce_min");
     }
 
     fn vector_reduce_max(
         &mut self,
-        src: <Self::CodegenCx as BackendTypes>::Value,
+        src: Value,
         is_signed: bool
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("vector_reduce_max");
     }
 
     fn extract_value(
         &mut self,
-        agg_val: <Self::CodegenCx as BackendTypes>::Value,
+        agg_val: Value,
         idx: u64
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("extract_value");
     }
 
     fn insert_value(
         &mut self,
-        agg_val: <Self::CodegenCx as BackendTypes>::Value,
-        elt: <Self::CodegenCx as BackendTypes>::Value,
+        agg_val: Value,
+        elt: Value,
         idx: u64
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("insert_value");
+    )-> Value {
+        // FIXME: insert elt into agg_val at idx
+        elt
     }
 
     fn landing_pad(
         &mut self,
-        ty: <Self::CodegenCx as BackendTypes>::Type,
-        pers_fn: <Self::CodegenCx as BackendTypes>::Value,
+        ty: Type,
+        pers_fn: Value,
         num_clauses: usize
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("landing_pad");
     }
 
     fn add_clause(
         &mut self,
-        landing_pad: <Self::CodegenCx as BackendTypes>::Value,
-        clause: <Self::CodegenCx as BackendTypes>::Value
+        landing_pad: Value,
+        clause: Value
     ) {
         unimplemented!("add_clause");
     }
 
     fn set_cleanup(
         &mut self,
-        landing_pad: <Self::CodegenCx as BackendTypes>::Value
+        landing_pad: Value
     ) {
         unimplemented!("set_cleanup");
     }
 
     fn resume(
         &mut self,
-        exn: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        exn: Value
+    )-> Value {
         unimplemented!("resume");
     }
 
     fn cleanup_pad(
         &mut self,
-        parent: Option<&'ll Value>,
-        args: &[&'ll Value]
+        parent: Option<Value>,
+        args: &[Value]
     ) {
         unimplemented!("cleanup_pad");
     }
@@ -880,15 +903,15 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn cleanup_ret(
         &mut self,
         cleanup: &<Self::CodegenCx as BackendTypes>::Funclet,
-        unwind: Option<<Self::CodegenCx as BackendTypes>::BasicBlock>,
-    ) -> <Self::CodegenCx as BackendTypes>::Value {
+        unwind: Option<BasicBlock>,
+    ) -> Value {
         unimplemented!("cleanup_ret");
     }
 
     fn catch_pad(
         &mut self,
-        parent: <Self::CodegenCx as BackendTypes>::Value,
-        args: &[<Self::CodegenCx as BackendTypes>::Value]
+        parent: Value,
+        args: &[Value]
     ) {
         unimplemented!("catch_pad");
     }
@@ -896,51 +919,51 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn catch_ret(
         &mut self,
         pad: &<Self::CodegenCx as BackendTypes>::Funclet,
-        unwind: <Self::CodegenCx as BackendTypes>::BasicBlock
-    ) -> <Self::CodegenCx as BackendTypes>::Value {
+        unwind: BasicBlock
+    ) -> Value {
         unimplemented!("catch_ret");
     }
 
     fn catch_switch(
         &mut self,
-        parent: Option<<Self::CodegenCx as BackendTypes>::Value>,
-        unwind: Option<<Self::CodegenCx as BackendTypes>::BasicBlock>,
+        parent: Option<Value>,
+        unwind: Option<BasicBlock>,
         num_handlers: usize,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("catch_switch");
     }
 
     fn add_handler(
         &mut self,
-        catch_switch: <Self::CodegenCx as BackendTypes>::Value,
-        handler: <Self::CodegenCx as BackendTypes>::BasicBlock
+        catch_switch: Value,
+        handler: BasicBlock
     ) {
         unimplemented!("add_handler");
     }
 
-    fn set_personality_fn(&mut self, personality: <Self::CodegenCx as BackendTypes>::Value) {
+    fn set_personality_fn(&mut self, personality: Value) {
         unimplemented!("set_personality_fn");
     }
 
     fn atomic_cmpxchg(
         &mut self,
-        dst: <Self::CodegenCx as BackendTypes>::Value,
-        cmp: <Self::CodegenCx as BackendTypes>::Value,
-        src: <Self::CodegenCx as BackendTypes>::Value,
+        dst: Value,
+        cmp: Value,
+        src: Value,
         order: AtomicOrdering,
         failure_order: AtomicOrdering,
         weak: bool,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("atomic_cmpxchg");
+    )-> Value {
+        unimplemented!("");
     }
 
     fn atomic_rmw(
         &mut self,
         op: AtomicRmwBinOp,
-        dst: <Self::CodegenCx as BackendTypes>::Value,
-        src: <Self::CodegenCx as BackendTypes>::Value,
+        dst: Value,
+        src: Value,
         order: AtomicOrdering,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+    )-> Value {
         unimplemented!("atomic_rmw");
     }
 
@@ -950,32 +973,32 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
     fn add_case(
         &mut self,
-        s: <Self::CodegenCx as BackendTypes>::Value,
-        on_val: <Self::CodegenCx as BackendTypes>::Value,
-        dest: <Self::CodegenCx as BackendTypes>::BasicBlock
+        s: Value,
+        on_val: Value,
+        dest: BasicBlock
     ) {
         unimplemented!("add_case(");
     }
 
     fn add_incoming_to_phi(
         &mut self,
-        phi: <Self::CodegenCx as BackendTypes>::Value,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        bb: <Self::CodegenCx as BackendTypes>::BasicBlock
+        phi: Value,
+        val: Value,
+        bb: BasicBlock
     ) {
         unimplemented!("add_incoming_to_phi");
     }
 
-    fn set_invariant_load(&mut self, load: <Self::CodegenCx as BackendTypes>::Value) {
+    fn set_invariant_load(&mut self, load: Value) {
         unimplemented!("set_invariant_load");
     }
 
     /// Returns the ptr value that should be used for storing `val`.
     fn check_store(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        ptr: <Self::CodegenCx as BackendTypes>::Value
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        ptr: Value
+    )-> Value {
         unimplemented!("check_store");
     }
 
@@ -983,43 +1006,44 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn check_call<'b>(
         &mut self,
         typ: &str,
-        llfn: <Self::CodegenCx as BackendTypes>::Value,
-        args: &'b [<Self::CodegenCx as BackendTypes>::Value]
-    ) -> Cow<'b, [<Self::CodegenCx as BackendTypes>::Value]>
-        where [<Self::CodegenCx as BackendTypes>::Value] : ToOwned {
+        llfn: Value,
+        args: &'b [Value]
+    ) -> Cow<'b, [Value]>
+        where [Value] : ToOwned {
         unimplemented!("check_call");
     }
 
-    fn lifetime_start(&mut self, ptr: <Self::CodegenCx as BackendTypes>::Value, size: Size) {
-        unimplemented!("lifetime_start");
+    fn lifetime_start(&mut self, ptr: Value, size: Size) {
+        // FIXME? nothing to do for now
     }
 
-    fn lifetime_end(&mut self, ptr: <Self::CodegenCx as BackendTypes>::Value, size: Size) {
-        unimplemented!("lifetime_end");
+    fn lifetime_end(&mut self, ptr: Value, size: Size) {
+        // FIXME? nothing to do for now
     }
 
     fn call(
         &mut self,
-        llfn: <Self::CodegenCx as BackendTypes>::Value,
-        args: &[<Self::CodegenCx as BackendTypes>::Value],
+        llfn: Value,
+        args: &[Value],
         funclet: Option<&Self::Funclet>,
-    )-> <Self::CodegenCx as BackendTypes>::Value {
-        unimplemented!("call");
+    )-> Value {
+        // FIXME: return a call instruction
+        Value::None
     }
 
     fn zext(
         &mut self,
-        val: <Self::CodegenCx as BackendTypes>::Value,
-        dest_ty: <Self::CodegenCx as BackendTypes>::Type
-    )-> <Self::CodegenCx as BackendTypes>::Value {
+        val: Value,
+        dest_ty: Type
+    )-> Value {
         unimplemented!("zext");
     }
 
-    unsafe fn delete_basic_block(&mut self, bb: <Self::CodegenCx as BackendTypes>::BasicBlock) {
-        unimplemented!("delete_basic_block)");
+    unsafe fn delete_basic_block(&mut self, bb: BasicBlock) {
+        unimplemented!("delete_basic_block");
     }
 
-    fn do_not_inline(&mut self, llret: <Self::CodegenCx as BackendTypes>::Value) {
+    fn do_not_inline(&mut self, llret: Value) {
         unimplemented!("do_not_inline");
     }
 
@@ -1058,8 +1082,13 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         unimplemented!("memset");
     }
 
-    fn load_operand(&mut self, place: PlaceRef<'tcx, Self::Value>)
-        -> OperandRef<'tcx, Self::Value> {
-        unimplemented!("load_operand");
+    fn load_operand(&mut self, place: PlaceRef<'tcx, Value>)
+        -> OperandRef<'tcx, Value> {
+        // FIXME?
+        let imm = to_immediate(self, place.llval, place.layout);
+        OperandRef {
+            val: OperandValue::Immediate(imm),
+            layout: place.layout,
+        }
     }
 }

--- a/src/librustc_codegen_ironox/consts.rs
+++ b/src/librustc_codegen_ironox/consts.rs
@@ -16,14 +16,22 @@ use rustc_codegen_ssa::traits::*;
 use rustc::hir::def_id::DefId;
 use rustc::ty::layout::Align;
 
+
 impl StaticMethods for CodegenCx<'ll, 'tcx> {
     fn static_addr_of(
         &self,
-        cv: &'ll Value,
+        cv: Value,
         align: Align,
         kind: Option<&str>,
-    ) -> &'ll Value {
-        unimplemented!("static_addr_of");
+    ) -> Value {
+        match cv {
+            Value::Local(_, _) => {
+                bug!("the address of a local cannot be known statically");
+            },
+            _ => {
+                unimplemented!("addr_of {:?}", cv);
+            }
+        }
     }
 
     fn codegen_static(

--- a/src/librustc_codegen_ironox/debuginfo/mod.rs
+++ b/src/librustc_codegen_ironox/debuginfo/mod.rs
@@ -14,13 +14,14 @@ use value::Value;
 
 use rustc::hir::def_id::CrateNum;
 use rustc::mir;
+use rustc::session::config::DebugInfo;
 use rustc::ty::{self, Ty};
 use rustc_codegen_ssa::debuginfo::{FunctionDebugContext, VariableAccess, MirDebugScope,
     VariableKind};
 use rustc_codegen_ssa::traits::{DebugInfoMethods, DebugInfoBuilderMethods};
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_mir::monomorphize::Instance;
-use syntax_pos;
+use syntax_pos::{self, BytePos};
 use syntax::ast;
 
 pub struct DIScope {}
@@ -32,17 +33,21 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         ty: Ty<'tcx>,
         vtable: Self::Value,
     ) {
-        unimplemented!("create_vtable_metadata");
+        // FIXME do nothing for now
     }
 
     fn create_function_debug_context(
         &self,
         instance: Instance<'tcx>,
         sig: ty::FnSig<'tcx>,
-        llfn: &'ll Value,
+        llfn: Value,
         mir: &mir::Mir,
-    ) -> FunctionDebugContext<&'ll DIScope> {
-        return FunctionDebugContext::DebugInfoDisabled;
+    ) -> FunctionDebugContext<Self::DIScope> {
+        if self.tcx.sess.opts.debuginfo == DebugInfo::None {
+            return FunctionDebugContext::DebugInfoDisabled;
+        } else {
+            unimplemented!("create_function_debug_context");
+        }
     }
 
     fn create_mir_scopes(
@@ -50,7 +55,17 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         mir: &mir::Mir,
         debug_context: &FunctionDebugContext<&'ll DIScope>,
     ) -> IndexVec<mir::SourceScope, MirDebugScope<&'ll DIScope>> {
-        IndexVec::new()
+        let null_scope = MirDebugScope {
+            scope_metadata: None,
+            file_start_pos: BytePos(0),
+            file_end_pos: BytePos(0)
+        };
+        let scopes = IndexVec::from_elem(null_scope, &mir.source_scopes);
+        if let FunctionDebugContext::DebugInfoDisabled = *debug_context {
+            return scopes;
+        } else {
+            unimplemented!("create_mir_scopes");
+        }
     }
 
     fn extend_scope_to_file(
@@ -80,7 +95,7 @@ impl<'a, 'll: 'a, 'tcx: 'll> DebugInfoBuilderMethods<'tcx>
         variable_name: ast::Name,
         variable_type: Ty<'tcx>,
         scope_metadata: &'ll DIScope,
-        variable_access: VariableAccess<'_, &'ll Value>,
+        variable_access: VariableAccess<'_, Value>,
         variable_kind: VariableKind,
         span: syntax_pos::Span,
     ) {
@@ -93,10 +108,10 @@ impl<'a, 'll: 'a, 'tcx: 'll> DebugInfoBuilderMethods<'tcx>
         scope: Option<&'ll DIScope>,
         span: syntax_pos::Span,
     ) {
-        unimplemented!("set_source_location");
+        // do nothing
     }
 
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
-        unimplemented!("insert_reference_to_gdb_debug_scripts_section_global");
+        // do nothing
     }
 }

--- a/src/librustc_codegen_ironox/declare.rs
+++ b/src/librustc_codegen_ironox/declare.rs
@@ -10,7 +10,7 @@
 
 use context::CodegenCx;
 use ironox_type::Type;
-use rustc::ty::PolyFnSig;
+use rustc::ty::{self, PolyFnSig};
 use rustc_codegen_ssa::traits::*;
 use value::Value;
 
@@ -18,16 +18,16 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn declare_global(
         &self,
-        name: &str, ty: &'ll Type
-    ) -> &'ll Value {
+        name: &str, ty: Type
+    ) -> Value {
         unimplemented!("declare_global");
     }
 
     fn declare_cfn(
         &self,
         name: &str,
-        fn_type: &'ll Type
-    ) -> &'ll Value {
+        fn_type: Type
+    ) -> Value {
         unimplemented!("declare_cfn");
     }
 
@@ -35,19 +35,19 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         &self,
         name: &str,
         sig: PolyFnSig<'tcx>,
-    ) -> &'ll Value {
+    ) -> Value {
         unimplemented!("declare_fn");
     }
 
     fn define_global(
         &self,
         name: &str,
-        ty: &'ll Type
-    ) -> Option<&'ll Value> {
+        ty: Type
+    ) -> Option<Value> {
         unimplemented!("define_global");
     }
 
-    fn define_private_global(&self, ty: &'ll Type) -> &'ll Value {
+    fn define_private_global(&self, ty: Type) -> Value {
         unimplemented!("define_private_global");
     }
 
@@ -55,7 +55,7 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         &self,
         name: &str,
         fn_sig: PolyFnSig<'tcx>,
-    ) -> &'ll Value {
+    ) -> Value {
         unimplemented!("define_fn");
     }
 
@@ -63,15 +63,17 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         &self,
         name: &str,
         fn_sig: PolyFnSig<'tcx>,
-    ) -> &'ll Value {
+    ) -> Value {
         unimplemented!("define_internal_fn");
     }
 
-    fn get_declared_value(&self, name: &str) -> Option<&'ll Value> {
+    fn get_declared_value(&self, name: &str) -> Option<Value> {
         unimplemented!("get_declared_value");
     }
 
-    fn get_defined_value(&self, name: &str) -> Option<&'ll Value> {
-        unimplemented!("get_defined_value");
+    fn get_defined_value(&self, name: &str) -> Option<Value> {
+        // FIXME: check if the value is a declaration (defined outside
+        // of the current translation unit)
+        self.get_declared_value(name)
     }
 }

--- a/src/librustc_codegen_ironox/function.rs
+++ b/src/librustc_codegen_ironox/function.rs
@@ -1,0 +1,59 @@
+// Copyright 2018 Gabriela-Alexandra Moldovan
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use basic_block::BasicBlockData;
+use ironox_type::{LLType, Type};
+use value::Value;
+use context::CodegenCx;
+
+use rustc::ty::FnSig;
+use rustc::ty::layout::Align;
+
+/// An IronOx function.
+#[derive(PartialEq, Debug)]
+pub struct IronOxFunction {
+    /// The name of the function.
+    pub name: String,
+    /// The basic blocks of the function.
+    pub basic_blocks: Vec<BasicBlockData>,
+    /// The parameters of the function.
+    pub params: Vec<Value>,
+}
+
+impl IronOxFunction {
+    pub fn new(
+        cx: &CodegenCx,
+        name: &str,
+        fn_type: Type) -> IronOxFunction {
+        match cx.types.borrow()[fn_type] {
+            LLType::FnType { ref args, ref ret } => {
+                // FIXME: populate params
+                let mut params = Vec::with_capacity(args.len());
+                IronOxFunction {
+                    name: name.to_string(),
+                    basic_blocks: vec![],
+                    params,
+                }
+            },
+            _ => bug!("Expected LLFnType, found {}", fn_type)
+        }
+    }
+
+    /// Return the specified parameter.
+    pub fn get_param(&self, index: usize) -> Value {
+        self.params[index]
+    }
+
+    /// Add a new basic block to this function.
+    ///
+    /// The basic block is inserted after the last basic block in the function.
+    pub fn add_bb(&mut self, bb: BasicBlockData) -> usize {
+        self.basic_blocks.push(bb);
+        self.basic_blocks.len() - 1
+    }
+}

--- a/src/librustc_codegen_ironox/intrinsic.rs
+++ b/src/librustc_codegen_ironox/intrinsic.rs
@@ -23,8 +23,8 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         callee_ty: Ty<'tcx>,
         fn_ty: &FnType<'tcx, Ty<'tcx>>,
-        args: &[OperandRef<'tcx, &'ll Value>],
-        llresult: &'ll Value,
+        args: &[OperandRef<'tcx, Value>],
+        llresult: Value,
         span: Span,
     ) {
         unimplemented!("codegen_intrinsic_call");
@@ -34,11 +34,11 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         unimplemented!("abort");
     }
 
-    fn assume(&mut self, val: &'ll Value) {
+    fn assume(&mut self, val: Value) {
         unimplemented!("assume");
     }
 
-    fn expect(&mut self, cond: &'ll Value, expected: bool) -> &'ll Value {
+    fn expect(&mut self, cond: Value, expected: bool) -> Value {
         unimplemented!("expect");
     }
 }

--- a/src/librustc_codegen_ironox/ironox_type.rs
+++ b/src/librustc_codegen_ironox/ironox_type.rs
@@ -14,142 +14,194 @@ use value::Value;
 use rustc_codegen_ssa::traits::{BaseTypeMethods, LayoutTypeMethods};
 use rustc_codegen_ssa::common::TypeKind;
 use rustc::util::nodemap::FxHashMap;
-use rustc::ty::{layout, Ty};
+use rustc::ty::{self, layout, Ty, TyCtxt};
 use rustc::ty::layout::TyLayout;
 use std::cell::RefCell;
+use rustc_target::abi::LayoutOf;
 use rustc_target::abi::call::{CastTarget, FnType, Reg};
 
+/// The type of a scalar.
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum ScalarType {
+    /// A 1-bit integer value.
+    I1,
+    /// An 8-bit integer value.
+    I8,
+    /// A 32-bit integer value.
+    I32,
+    /// An integer value which has a target-dependent size.
+    ISize,
+    /// An integer value of a custom size.
+    Ix(u64),
+}
+
+/// A `Type` is an index into the vector of types in the codegen context.
+pub type Type = usize;
+
+/// The actual types.
 #[derive(PartialEq, Debug)]
-pub struct Type {
-    size: u64
+pub enum LLType {
+    /// A function type.
+    FnType {
+        args: Vec<Type>,
+        ret: Type
+    },
+    /// A scalar type.
+    Scalar(ScalarType),
+    /// A placeholder for types. This will be removed later.
+    None,
 }
 
 impl CodegenCx<'ll, 'tcx> {
-    crate fn type_named_struct(&self, name: &str) -> &'ll Type {
+    crate fn type_named_struct(&self, name: &str) -> &Type {
         unimplemented!("type_named_struct");
     }
 
-    crate fn set_struct_body(&self, ty: &'ll Type, els: &[&'ll Type], packed: bool) {
+    crate fn set_struct_body(&self, ty: &Type, els: &[&Type], packed: bool) {
         unimplemented!("set_struct_body");
     }
 }
 
 impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
-    fn type_void(&self) -> &'ll Type {
+    fn type_void(&self) -> Type {
         unimplemented!("type_void");
     }
 
-    fn type_metadata(&self) -> &'ll Type {
+    fn type_metadata(&self) -> Type {
         unimplemented!("type_metadata");
     }
 
-    fn type_i1(&self) -> &'ll Type {
-        unimplemented!("type_i1");
+    fn type_i1(&self) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::Scalar(ScalarType::I1));
+        borrowed_types.len() - 1
     }
 
-    fn type_i8(&self) -> &'ll Type {
-        unimplemented!("type_i8");
+    fn type_i8(&self) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::Scalar(ScalarType::I8));
+        borrowed_types.len() - 1
     }
 
-
-    fn type_i16(&self) -> &'ll Type {
+    fn type_i16(&self) -> Type {
         unimplemented!("type_i16");
     }
 
-    fn type_i32(&self) -> &'ll Type {
-        unimplemented!("type_i32");
+    fn type_i32(&self) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::Scalar(ScalarType::I32));
+        borrowed_types.len() - 1
     }
 
-    fn type_i64(&self) -> &'ll Type {
+    fn type_i64(&self) -> Type {
         unimplemented!("type_i64");
     }
 
-    fn type_i128(&self) -> &'ll Type {
+    fn type_i128(&self) -> Type {
         unimplemented!("type_i128");
     }
 
-    fn type_ix(&self, num_bits: u64) -> &'ll Type {
-        unimplemented!("type_ix");
+    fn type_ix(&self, num_bits: u64) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::Scalar(ScalarType::Ix(num_bits)));
+        borrowed_types.len() - 1
     }
 
-    fn type_isize(&self) -> &'ll Type {
-        unimplemented!("type_isize");
+    fn type_isize(&self) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::Scalar(ScalarType::ISize));
+        borrowed_types.len() - 1
     }
 
-    fn type_f32(&self) -> &'ll Type {
+    fn type_f32(&self) -> Type {
         unimplemented!("type_f32");
     }
 
-    fn type_f64(&self) -> &'ll Type {
+    fn type_f64(&self) -> Type {
         unimplemented!("type_f64");
     }
 
-    fn type_x86_mmx(&self) -> &'ll Type {
+    fn type_x86_mmx(&self) -> Type {
         unimplemented!("type_x86_mmx");
     }
 
     fn type_func(
         &self,
-        args: &[&'ll Type],
-        ret: &'ll Type
-    ) -> &'ll Type {
-        unimplemented!("type_func");
+        args: &[Type],
+        ret: Type
+    ) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        // define the types of the arguments of the function
+        let mut ll_args = vec![];
+        for arg in args {
+            ll_args.push(arg.clone());
+        }
+        // return a FnType that can be used to declare a function
+        let fn_type = LLType::FnType {
+            args: ll_args,
+            ret: ret.clone(),
+        };
+        borrowed_types.push(fn_type);
+        borrowed_types.len() - 1
     }
 
     fn type_variadic_func(
         &self,
-        args: &[&'ll Type],
-        ret: &'ll Type
-    ) -> &'ll Type {
+        args: &[Type],
+        ret: Type
+    ) -> Type {
         unimplemented!("type_variadic_func");
     }
 
     fn type_struct(
         &self,
-        els: &[&'ll Type],
+        els: &[Type],
         packed: bool
-    ) -> &'ll Type {
+    ) -> Type {
         unimplemented!("type_struct");
     }
 
-    fn type_array(&self, ty: &'ll Type, len: u64) -> &'ll Type {
+    fn type_array(&self, ty: Type, len: u64) -> Type {
         unimplemented!("type_array");
     }
 
-    fn type_vector(&self, ty: &'ll Type, len: u64) -> &'ll Type {
+    fn type_vector(&self, ty: Type, len: u64) -> Type {
         unimplemented!("type_vector");
     }
 
-    fn type_kind(&self, ty: &'ll Type) -> TypeKind {
+    fn type_kind(&self, ty: Type) -> TypeKind {
         unimplemented!("type_kind");
     }
 
-    fn type_ptr_to(&self, ty: &'ll Type) -> &'ll Type {
+    fn type_ptr_to(&self, ty: Type) -> Type {
         unimplemented!("type_ptr_to");
     }
 
-    fn element_type(&self, ty: &'ll Type) -> &'ll Type {
+    fn element_type(&self, ty: Type) -> Type {
         unimplemented!("element_type");
     }
 
-    fn vector_length(&self, ty: &'ll Type) -> usize {
+    fn vector_length(&self, ty: Type) -> usize {
         unimplemented!("vector_length");
     }
 
-    fn func_params_types(&self, ty: &'ll Type) -> Vec<&'ll Type> {
+    fn func_params_types(&self, ty: Type) -> Vec<Type> {
         unimplemented!("func_params_types");
     }
 
-    fn float_width(&self, ty : &'ll Type) -> usize {
+    fn float_width(&self, ty : Type) -> usize {
         unimplemented!("float_width");
     }
 
-    fn int_width(&self, ty: &'ll Type) -> u64 {
+    fn int_width(&self, ty: Type) -> u64 {
         unimplemented!("int_width");
     }
 
-    fn val_ty(&self, v: &'ll Value) -> &'ll Type {
-        unimplemented!("val_ty");
+    fn val_ty(&self, v: Value) -> Type {
+        // FIXME: return the real type
+        let mut borrowed_types = self.types.borrow_mut();
+        borrowed_types.push(LLType::None);
+        borrowed_types.len() - 1
     }
 
     fn scalar_lltypes(&self) -> &RefCell<FxHashMap<Ty<'tcx>, Self::Type>> {
@@ -158,12 +210,41 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 }
 
 impl LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
-    fn backend_type(&self, ty: TyLayout<'tcx>) -> &'ll Type {
-        unimplemented!("backend_type");
+    fn backend_type(&self, ty: TyLayout<'tcx>) -> Type {
+        let ironox_ty = match ty.ty.sty {
+            ty::Ref(_, ty, _) |
+            ty::RawPtr(ty::TypeAndMut { ty, .. }) => {
+                self.type_ptr_to(self.backend_type(self.layout_of(ty)))
+            }
+            ty::Adt(def, _) if def.is_box() => {
+                let mut borrowed_types = self.types.borrow_mut();
+                // FIXME: return the real type
+                borrowed_types.push(LLType::None);
+                borrowed_types.len() - 1
+            }
+            ty::FnPtr(sig) => {
+                let mut borrowed_types = self.types.borrow_mut();
+                // FIXME: return the real type
+                borrowed_types.push(LLType::None);
+                borrowed_types.len() - 1
+            }
+            _ => {
+                let mut borrowed_types = self.types.borrow_mut();
+                // FIXME: return the real type
+                borrowed_types.push(LLType::None);
+                borrowed_types.len() - 1
+            }
+        };
+        ironox_ty
     }
-    fn immediate_backend_type(&self, ty: TyLayout<'tcx>) -> &'ll Type {
-        unimplemented!("immediate_backend_type");
+
+    fn immediate_backend_type(&self, ty: TyLayout<'tcx>) -> Type {
+        let mut borrowed_types = self.types.borrow_mut();
+        // FIXME: return the real type
+        borrowed_types.push(LLType::None);
+        borrowed_types.len() - 1
     }
+
     fn is_backend_immediate(&self, ty: TyLayout<'tcx>) -> bool {
         match ty.abi {
             layout::Abi::Scalar(_) |
@@ -173,6 +254,7 @@ impl LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             layout::Abi::Aggregate { .. } => ty.is_zst()
         }
     }
+
     fn is_backend_scalar_pair(&self, ty: TyLayout<'tcx>) -> bool {
         match ty.abi {
             layout::Abi::ScalarPair(..) => true,
@@ -182,27 +264,33 @@ impl LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             layout::Abi::Aggregate { .. } => false
         }
     }
+
     fn backend_field_index(&self, ty: TyLayout<'tcx>, index: usize) -> u64 {
         unimplemented!("backend_field_index");
     }
+
     fn scalar_pair_element_backend_type<'a>(
         &self,
         ty: TyLayout<'tcx>,
         index: usize,
         immediate: bool
-    ) -> &'ll Type {
+    ) -> Type {
         unimplemented!("scalar_pair_element_backend_type");
     }
-    fn cast_backend_type(&self, ty: &CastTarget) -> &'ll Type {
+
+    fn cast_backend_type(&self, ty: &CastTarget) -> Type {
         unimplemented!("cast_backend_type");
     }
-    fn fn_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> &'ll Type {
+
+    fn fn_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> Type {
         unimplemented!("fn_backend_type");
     }
-    fn reg_backend_type(&self, ty: &Reg) -> &'ll Type {
+
+    fn reg_backend_type(&self, ty: &Reg) -> Type {
         unimplemented!("reg_backend_type");
     }
-    fn fn_ptr_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> &'ll Type {
+
+    fn fn_ptr_backend_type(&self, ty: &FnType<'tcx, Ty<'tcx>>) -> Type {
         unimplemented!("fn_ptr_backend_type");
     }
 }

--- a/src/librustc_codegen_ironox/mono_item.rs
+++ b/src/librustc_codegen_ironox/mono_item.rs
@@ -34,7 +34,7 @@ impl PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     visibility: Visibility,
                     symbol_name: &str) {
 
-        // insert an empty value for now
-        self.instances.borrow_mut().insert(instance, &Value {});
+        // FIXME: this should not be a ConstUndef (it should be a function)
+        self.instances.borrow_mut().insert(instance, Value::ConstUndef);
     }
 }

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -6,12 +6,25 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::fmt;
 use std::hash::{Hash, Hasher};
 
-#[allow(dead_code)]
-#[derive(Debug, PartialEq)]
-pub struct Value {}
+/// The unique identifier of an IronOx value.
+///
+/// Each enum variant has one or more indices that can be used to retrieve the
+/// value from the context.
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub enum Value {
+    /// The index of an `IronOxFunction` function in the module.
+    Function(usize),
+    /// A `(function index, local index)` pair that can be used to retrieve a
+    /// local value.
+    Local(usize, usize),
+    /// An unspecified constant. This is just a wrapper around a `Type`.
+    ConstUndef,
+    BigConst(u128),
+    Global,
+    None,
+}
 
 impl Eq for Value {}
 


### PR DESCRIPTION
A summary of the changes:

* Change &'ll Value to Value
* Define `IronOxFunction`: the internal representation of functions
* Define structures to represent basic blocks
* Define some of the data types that will be used by the ironox backend:
   * ScalarType
   * FnType
* Implement `type_func` (returns a function type)
* Implement several `type_i*` functions: `type_i1`, `type_i8` etc
* Add functions to `ModuleIronOx`

Most of the changes in this PR don't need to be reviewed (I replaced `&'ll Value` with `Value`, and `&'ll Type` with `Type` everywhere, which is why there are loads of line changes).

These are just some of the changes from the large set of changes I'll try to merge over the next few days.