### PR TITLE
Run the tests instead of ./x.py check.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+#
+# Build script for continuous integration.
 
-./x.py clean
-RUST_BACKTRACE=1 ./x.py check --config .buildbot.toml
+./x.py clean  # We don't clone afresh to save time and bandwidth.
+git clean -dffx # If upstream removes a submodule, remove the files from disk.
+
+# Note that the gdb must be Python enabled.
+PATH=/opt/gdb-8.2/bin:${PATH} RUST_BACKTRACE=1 \
+./x.py test --config .buildbot.toml

--- a/.buildbot.toml
+++ b/.buildbot.toml
@@ -1,4 +1,8 @@
 # Config file for continuous integration.
 
 [rust]
-codegen-backends = ["ironox"]
+codegen-units = 0           # Use many compilation units.
+debug-assertions = true     # Turn on assertions in rustc.
+
+[llvm]
+assertions = true # Turn on assertions in LLVM.


### PR DESCRIPTION
This runs the tests for the llvm backend.