### PR TITLE
Type conversion

### DIFF
--- a/src/librustc_codegen_ironox/abi.rs
+++ b/src/librustc_codegen_ironox/abi.rs
@@ -149,7 +149,8 @@ impl FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
             mode => unimplemented!("{:?}", mode)
         };
         // Create the types of the arguments.
-        let mut arg_tys = vec![];
+        let mut arg_tys = Vec::with_capacity(self.args.len());
+
         for arg in &self.args {
             let arg_ty = match arg.mode {
                 PassMode::Ignore => continue,

--- a/src/librustc_codegen_ironox/abi.rs
+++ b/src/librustc_codegen_ironox/abi.rs
@@ -12,14 +12,18 @@ use builder::Builder;
 use context::CodegenCx;
 use value::Value;
 use type_::Type;
+use type_of::LayoutIronOxExt;
+
+use libc::c_uint;
 
 use rustc::ty::{self, Ty, Instance};
-use rustc_codegen_ssa::traits::{AbiMethods, AbiBuilderMethods, ArgTypeMethods,
-    BackendTypes};
+use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::mir::place::PlaceRef;
-use rustc_target::abi::call::*;
+use rustc_codegen_ssa::mir::operand::OperandValue;
 use rustc_target::abi::LayoutOf;
-use rustc_target::spec::abi::Abi;
+
+pub use rustc_target::spec::abi::Abi;
+pub use rustc_target::abi::call::*;
 
 impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     fn apply_attrs_callsite(
@@ -27,7 +31,7 @@ impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         ty: &FnType<'tcx, Ty<'tcx>>,
         callsite: Value
     ) {
-        unimplemented!("apply_attrs_callsite");
+        // FIXME?
     }
 }
 
@@ -38,7 +42,31 @@ impl ArgTypeMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         idx: &mut usize,
         dst: PlaceRef<'tcx, Value>
     ) {
-        unimplemented!("store_fn_arg");
+        match ty.mode {
+            PassMode::Ignore => {},
+            PassMode::Pair(..) => {
+                unimplemented!("PassMode::Pair");
+            }
+            PassMode::Indirect(_, Some(_)) => {
+                unimplemented!("PassMode::Indirect");
+            }
+            PassMode::Direct(_) | PassMode::Indirect(_, None) | PassMode::Cast(_) => {
+                if ty.is_ignore() {
+                    return;
+                }
+                let val = self.cx.get_param(self.llfn(), *idx as c_uint);
+                *idx += 1;
+                if ty.is_sized_indirect() {
+                    unimplemented!("sized indirect");
+                } else if ty.is_unsized_indirect() {
+                    bug!("unsized ArgType must be handled through store_fn_arg");
+                } else if let PassMode::Cast(cast) = ty.mode {
+                    unimplemented!("PassMode::Cast");
+                } else {
+                    OperandValue::Immediate(val).store(self, dst);
+                }
+            }
+        }
     }
 
     fn store_arg_ty(
@@ -55,11 +83,20 @@ impl ArgTypeMethods<'tcx> for Builder<'a, 'll, 'tcx> {
     }
 }
 
-impl AbiMethods<'tcx> for CodegenCx<'ll, 'tcx> {
-    fn new_fn_type(&self, sig: ty::FnSig<'tcx>, extra_args: &[Ty<'tcx>])
-        -> FnType<'tcx, Ty<'tcx>> {
+pub trait FnTypeExt<'tcx> {
+    fn new(cx: &CodegenCx<'_, 'tcx>, sig: ty::FnSig<'tcx>,
+           extra_args: &[Ty<'tcx>]) -> Self;
+    fn ironox_type(&self, cx: &CodegenCx<'a, 'tcx>) -> Type;
+}
+
+impl FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
+    fn new(
+        cx: &CodegenCx<'_, 'tcx>,
+        sig: ty::FnSig<'tcx>,
+        extra_args: &[Ty<'tcx>]) -> Self {
         use self::Abi::*;
-        let conv = match self.tcx.sess.target.target.adjust_abi(sig.abi) {
+
+        let conv = match cx.tcx.sess.target.target.adjust_abi(sig.abi) {
             RustIntrinsic | PlatformIntrinsic |
             Rust | RustCall => Conv::C,
             System => bug!("system abi should be selected elsewhere"),
@@ -68,13 +105,73 @@ impl AbiMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             Cdecl => Conv::C,
             _ => unimplemented!("Unknown calling convention")
         };
-        // return the FnType
-        FnType {
-            ret: ArgType::new(self.layout_of(sig.output())),
-            args: vec![],
+
+        // Create an ArgType for a function argument of type `ty`.
+        // `arg_idx` is None if `ty` is the return type, and Some(index),
+        // if `ty` is the type of an argument.
+        let arg_of = |ty: Ty<'tcx>, arg_idx: Option<usize>| {
+            let is_return = arg_idx.is_none();
+            // The ArgType of the specified ty.
+            let mut arg = ArgType::new(cx.layout_of(ty));
+            // Does the function adhere to the Rust ABI?
+            let rust_abi = match sig.abi {
+                RustIntrinsic | PlatformIntrinsic | Rust | RustCall => true,
+                _ => false
+            };
+            // Is this a zero-sized type?
+            if arg.layout.is_zst() {
+                if is_return || rust_abi {
+                    arg.mode = PassMode::Ignore;
+                }
+            }
+            arg
+        };
+        // Return the FnType of this function.
+        let mut fn_ty = FnType {
+            ret: arg_of(sig.output(), None),
+            args: sig.inputs().iter().chain(extra_args).enumerate().map(|(i, ty)| {
+                arg_of(ty, Some(i))
+            }).collect(),
             variadic: sig.variadic,
             conv
+        };
+        fn_ty
+    }
+
+    /// Return the IronOx `Type` of this `FnType`.
+    fn ironox_type(&self, cx: &CodegenCx<'a, 'tcx>) -> Type {
+        // Create the return type.
+        let ret_ty = match self.ret.mode {
+            PassMode::Ignore => cx.type_void(),
+            PassMode::Direct(_) => {
+                self.ret.layout.immediate_ironox_type(cx)
+            },
+            mode => unimplemented!("{:?}", mode)
+        };
+        // Create the types of the arguments.
+        let mut arg_tys = vec![];
+        for arg in &self.args {
+            let arg_ty = match arg.mode {
+                PassMode::Ignore => continue,
+                PassMode::Direct(_) => {
+                    arg.layout.immediate_ironox_type(cx)
+                },
+                mode => unimplemented!("{:?}", mode),
+            };
+            arg_tys.push(arg_ty);
         }
+        if self.variadic {
+            cx.type_variadic_func(&arg_tys, ret_ty)
+        } else {
+            cx.type_func(&arg_tys, ret_ty)
+        }
+    }
+}
+
+impl AbiMethods<'tcx> for CodegenCx<'ll, 'tcx> {
+    fn new_fn_type(&self, sig: ty::FnSig<'tcx>, extra_args: &[Ty<'tcx>])
+        -> FnType<'tcx, Ty<'tcx>> {
+        FnType::new(&self, sig, extra_args)
     }
 
     fn new_vtable(

--- a/src/librustc_codegen_ironox/context.rs
+++ b/src/librustc_codegen_ironox/context.rs
@@ -58,7 +58,10 @@ pub struct CodegenCx<'ll, 'tcx: 'll> {
     pub vtables: RefCell<
         FxHashMap<(Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>), Value>>,
     eh_personality: Cell<Option<Value>>,
+    /// All the types defined in this context.
     pub types: RefCell<Vec<LLType>>,
+    /// The index of an `LLType` in `types`.
+    pub type_cache: RefCell<FxHashMap<LLType, Type>>,
 }
 
 impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
@@ -75,6 +78,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             vtables: Default::default(),
             eh_personality: Default::default(),
             types: Default::default(),
+            type_cache: Default::default(),
         }
     }
 

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -82,6 +82,7 @@ mod debuginfo;
 mod declare;
 mod intrinsic;
 mod type_;
+mod type_of;
 mod metadata;
 mod mono_item;
 mod value;

--- a/src/librustc_codegen_ironox/type_of.rs
+++ b/src/librustc_codegen_ironox/type_of.rs
@@ -1,0 +1,26 @@
+use context::CodegenCx;
+use type_::Type;
+
+use rustc::ty::layout::{self, TyLayout};
+
+pub trait LayoutIronOxExt<'tcx> {
+    fn ironox_type(&self, cx: &CodegenCx<'_, 'tcx>) -> Type;
+    fn immediate_ironox_type(&self, cx: &CodegenCx<'_, 'tcx>) -> Type;
+    fn scalar_ironox_type_at(&self, cx: &CodegenCx<'_, 'tcx>,
+                             scalar: &layout::Scalar) -> Type;
+}
+
+impl LayoutIronOxExt<'tcx> for TyLayout<'tcx> {
+    fn ironox_type(&self, cx: &CodegenCx<'_, 'tcx>) -> Type {
+        unimplemented!("ironox_type");
+    }
+
+    fn immediate_ironox_type(&self, cx: &CodegenCx<'_, 'tcx>) -> Type {
+        unimplemented!("immediate_ironox_type");
+    }
+
+    fn scalar_ironox_type_at(&self, cx: &CodegenCx<'_, 'tcx>,
+                             scalar: &layout::Scalar) -> Type {
+        unimplemented!("scalar_ironox_type_at");
+    }
+}


### PR DESCRIPTION
This a bit large, so it might be easier to review each commit individually.

* `store_fn_arg` from `ArgTypeMethods` stores a function argument of type `ArgType` into a specified destination (a `PlaceRef`). This commit handles some of the possible `PassMode`s of the argument.
* `new_fn_type` from `AbiMethods` returns the ironox function type for a given `ty::FnSig`. To simplify the implementation (and to be consistent with the way the LLVM backend achieves this), I defined an `FnTypeExt` trait. This trait is implemented for `FnType`s. The functions in `FnTypeExt` make it easy to
create a `FnType` from a `ty::FnSig`, and to convert the `FnType` to an ironox function type.

* Implement `type_named_struct` and `set_struct_body` to create struct types.
* Implement several `BaseTypeMethods`: `type_void`,  `type_struct`, `type_array`, `type_ptr_to`. These all return an ironox `Type`.
* Implement `LayoutIronOxExt` for `TyLayout`.