### PR TITLE
Implement function declarations.

### DIFF
--- a/src/librustc_codegen_ironox/mono_item.rs
+++ b/src/librustc_codegen_ironox/mono_item.rs
@@ -33,8 +33,10 @@ impl PreDefineMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                     linkage: Linkage,
                     visibility: Visibility,
                     symbol_name: &str) {
-
-        // FIXME: this should not be a ConstUndef (it should be a function)
-        self.instances.borrow_mut().insert(instance, Value::ConstUndef);
+        let mono_sig = instance.fn_sig(self.tcx);
+        // Create an IronOx function for this instance.
+        let fn_decl = self.declare_fn(symbol_name, mono_sig);
+        // Map the instance to the IronOx function it corresponds to.
+        self.instances.borrow_mut().insert(instance, fn_decl);
     }
 }


### PR DESCRIPTION
This implements the functions that create the backend-specific representation of functions.

* `predefine_fn`: maps `Instances` to ironox functions
* `declare_cfn`: creates an ironox function of a given `Type`
* `declare_fn`: create an ironox function with a given signature