### PR TITLE
Create an insertion point for the builder.

### DIFF
--- a/src/librustc_codegen_ironox/ir/function.rs
+++ b/src/librustc_codegen_ironox/ir/function.rs
@@ -8,7 +8,7 @@
 
 use super::basic_block::BasicBlockData;
 use type_::{LLType, Type};
-use value::Value;
+use value::{Instruction, Value};
 use context::CodegenCx;
 
 use rustc::ty::FnSig;
@@ -51,6 +51,19 @@ impl IronOxFunction {
             },
             _ => bug!("Expected LLFnType, found {}", fn_type)
         }
+    }
+
+    /// Insert the instruction at a specified position in a basic block.
+    pub fn insert_inst(
+        &mut self,
+        bb_idx: usize,
+        inst_idx: usize,
+        inst: Instruction) {
+        assert!(
+            bb_idx < self.basic_blocks.len()
+                && inst_idx <= self.basic_blocks[bb_idx].instrs.len(),
+            "Invalid insertion point!");
+        self.basic_blocks[bb_idx].instrs.insert(inst_idx, inst)
     }
 
     /// Return the specified parameter.

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -147,12 +147,19 @@ pub struct ModuleIronOx {
 }
 
 impl ModuleIronOx {
+    /// Create an empty module.
     pub fn new() -> ModuleIronOx {
         ModuleIronOx {
             functions: vec![],
         }
     }
 
+    /// Get the function at index `fn_idx`.
+    pub fn get_function(&mut self, fn_idx: usize) -> &mut IronOxFunction {
+        &mut self.functions[fn_idx]
+    }
+
+    /// Add a new function of a particular `Type`.
     pub fn add_function_with_type(
         &mut self,
         cx: &CodegenCx,
@@ -163,7 +170,7 @@ impl ModuleIronOx {
     }
 
     pub fn asm(&self) -> String {
-        "not actual asm".to_string()
+        "nop".to_string()
     }
 }
 

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -35,6 +35,7 @@ pub enum Value {
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum Instruction {
     // FIXME: implement
+    None,
 }
 
 impl Eq for Value {}


### PR DESCRIPTION
The instruction `Builder` now uses a `BuilderPosition` to keep track of the insertion point. A `BuilderPosition` consists of a function index, a basic block index, and an instruction index.

When a function from `BuilderMethods` (`call`, `add`, `ret` etc) is called, the builder adds an `Instruction` at a specific position in the `IronOxModule` (the position is the `BuilderPosition` stored in the `Builder`).

`emit_instr` from `Builder` adds an instruction at the current `BuilderPosition`. 

`IronOxFunction`s now have an `insert_inst` function, which inserts an instruction at a particular position in a basic block.
