### PR TITLE
Create the asm files and call the assembler.

### DIFF
--- a/src/librustc_codegen_ironox/base.rs
+++ b/src/librustc_codegen_ironox/base.rs
@@ -11,11 +11,12 @@
 use super::{IronOxCodegenBackend, ModuleIronOx};
 use rustc::mir::mono::Stats;
 use rustc::ty::TyCtxt;
-use rustc_codegen_ssa::back::write::submit_codegened_module_to_llvm;
 use rustc_codegen_ssa::base::maybe_create_entry_wrapper;
+use rustc_codegen_ssa::back::write::submit_codegened_module_to_llvm;
 use rustc_codegen_ssa::{ModuleCodegen, ModuleKind};
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::mono_item::MonoItemExt;
+use rustc_mir::monomorphize::MonoItem;
 use rustc_mir::monomorphize::partitioning::CodegenUnitExt;
 use syntax_pos::symbol::InternedString;
 
@@ -26,7 +27,6 @@ pub fn compile_codegen_unit<'ll, 'tcx>(
     tcx: TyCtxt<'ll, 'tcx, 'tcx>,
     cgu_name: InternedString,
 ) -> Stats {
-
     let dep_node = tcx.codegen_unit(cgu_name).codegen_dep_node(tcx);
     let ((stats, module), _) = tcx.dep_graph.with_task(dep_node,
                                                        tcx,
@@ -51,8 +51,6 @@ fn codegen_ironox_module<'ll, 'tcx>(
         for &(mono_item, (linkage, visibility)) in &mono_items {
             mono_item.predefine::<Builder>(&cx, linkage, visibility);
         }
-
-        // ... and now that we have everything pre-defined, fill out those definitions.
         for &(mono_item, _) in &mono_items {
             mono_item.define::<Builder>(&cx);
         }

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -242,33 +242,12 @@ impl WriteBackendMethods for IronOxCodegenBackend {
 
     unsafe fn codegen(
         cgcx: &CodegenContext<Self>,
-        _diag_handler: &Handler,
+        diag_handler: &Handler,
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
-        _timeline: &mut Timeline
+        timeline: &mut Timeline
     ) -> Result<CompiledModule, FatalError> {
-        // FIXME fix this
-        if true || config.no_integrated_as {
-            let object = cgcx.output_filenames
-                .temp_path(OutputType::Object, Some(&module.name));
-            let filename = object.to_str().unwrap().to_string();
-            let mut cmd = Command::new("as").arg("-o").arg(filename)
-                .stdin(Stdio::piped()).spawn().expect("failed to run as");
-            {
-                let stdin = cmd.stdin.as_mut().expect("failed to open stdin");
-                stdin.write_all(module.module_llvm.asm().as_bytes())
-                    .expect("failed to write to stdin");
-            }
-            Ok(CompiledModule {
-                name: module.name.clone(),
-                kind: module.kind,
-                object: Some(object),
-                bytecode: None,
-                bytecode_compressed: None,
-            })
-        } else {
-            unimplemented!("ironox does not have an integrated assembler!");
-        }
+        back::write::codegen(cgcx, diag_handler, module, config, timeline)
     }
 
     fn prepare_thin(


### PR DESCRIPTION
This moves the code from `codegen` to `back::write::codegen`.

`write_mdoule` writes the assembly instructions from a `ModuleIronOx` (generated from the IR of the module using `module.asm()`) to a file. 

`back::write::codegen` calls `write_module` for every compiled module, and runs the assembler on all the assembly files created.