### PR TITLE
Constants

### DIFF
--- a/src/librustc_codegen_ironox/constant.rs
+++ b/src/librustc_codegen_ironox/constant.rs
@@ -1,0 +1,19 @@
+use type_::Type;
+
+/// An unsigned constant. Its value must fit in a `u128`.
+#[derive(Clone, Copy, Debug)]
+pub struct UnsignedConst {
+    /// The type of the constant.
+    pub ty: Type,
+    /// The value of the constant.
+    pub value: u128,
+}
+
+/// A signed constant. Its value must fit in a `i128`.
+#[derive(Clone, Copy, Debug)]
+pub struct SignedConst {
+    /// The type of the constant.
+    pub ty: Type,
+    /// The value of the constant.
+    pub value: i128,
+}

--- a/src/librustc_codegen_ironox/declare.rs
+++ b/src/librustc_codegen_ironox/declare.rs
@@ -30,7 +30,7 @@ impl DeclareMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         name: &str,
         fn_type: Type
     ) -> Value {
-        self.module.borrow_mut().add_function_with_type(self, name, fn_type)
+        self.module.borrow_mut().add_function(self, name, fn_type)
     }
 
     fn declare_fn(

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -143,6 +143,7 @@ impl ExtraBackendMethods for IronOxCodegenBackend {
 
 #[derive(Debug)]
 pub struct ModuleIronOx {
+    /// The functions defined in this module
     pub functions: Vec<IronOxFunction>,
 }
 
@@ -150,7 +151,7 @@ impl ModuleIronOx {
     /// Create an empty module.
     pub fn new() -> ModuleIronOx {
         ModuleIronOx {
-            functions: vec![],
+            functions: Default::default(),
         }
     }
 
@@ -160,7 +161,7 @@ impl ModuleIronOx {
     }
 
     /// Add a new function of a particular `Type`.
-    pub fn add_function_with_type(
+    pub fn add_function(
         &mut self,
         cx: &CodegenCx,
         name: &str,

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -76,6 +76,7 @@ mod abi;
 mod asm;
 mod base;
 mod builder;
+mod constant;
 mod consts;
 mod context;
 mod debuginfo;

--- a/src/librustc_codegen_ironox/type_.rs
+++ b/src/librustc_codegen_ironox/type_.rs
@@ -226,7 +226,18 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     }
 
     fn val_ty(&self, v: Value) -> Type {
-        unimplemented!("val_ty({:?})", v);
+        let mut borrowed_types = self.types.borrow_mut();
+        match v {
+            Value::ConstUint(const_idx) => {
+                self.u_consts.borrow()[const_idx].ty
+            },
+            Value::ConstInt(const_idx) => {
+                self.i_consts.borrow()[const_idx].ty
+            },
+            _ => {
+                unimplemented!("type of {:?}", v);
+            }
+        }
     }
 
     fn scalar_lltypes(&self) -> &RefCell<FxHashMap<Ty<'tcx>, Self::Type>> {

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -23,7 +23,7 @@ pub enum Value {
     /// An unspecified constant. This is just a wrapper around a `Type`.
     ConstUndef,
     BigConst(u128),
-    Global,
+    Global(Type),
     /// The index of an `IronOxStruct` in the `structs` vec from `ModuleIronOx`.
     ConstStruct(usize),
     /// The parameter of an `IronOxFunction`. This is just a wrapper around a `Type`.

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -20,10 +20,12 @@ pub enum Value {
     /// A `(function index, local index)` pair that can be used to retrieve a
     /// local value.
     Local(usize, usize),
-    /// An unspecified constant. This is just a wrapper around a `Type`.
-    ConstUndef,
-    BigConst(u128),
-    Global(Type),
+    /// An uninitialized constant. This is just a wrapper around a `Type`.
+    ConstUndef(Type),
+    /// The index of an `UnsignedConst` in `u_consts`.
+    ConstUint(usize),
+    /// The index of a `SignedConst` in `i_consts`.
+    ConstInt(usize),
     /// The index of an `IronOxStruct` in the `structs` vec from `ModuleIronOx`.
     ConstStruct(usize),
     /// The parameter of an `IronOxFunction`. This is just a wrapper around a `Type`.


### PR DESCRIPTION
The backend can now compile constants. This PR adds the implementation of some of the `ConstMethods` of the `CodegenCx`.

A `SignedConst`/`UnsignedConst` is a (typed) constant value. The `SignedConst`/`UnsignedConst`s are stored in the `i_consts`/`u_consts` vectors from the `CodegenCx`.

`Value` has two new variants which represent constants:

* `ConstUint(x)` - x is the index of a constant in the `u_consts` vector
* `ConstInt(x)` - x is the index of a constant in the `i_consts` vector


