### PR TITLE
Only run the assembler on regular modules.

### DIFF
--- a/src/librustc_codegen_ironox/back/write.rs
+++ b/src/librustc_codegen_ironox/back/write.rs
@@ -25,8 +25,15 @@ fn write_module(
     module: &ModuleIronOx,
     path: &PathBuf,
     diag_handler: &Handler) {
-    if let Err(e) = fs::write(path, module.asm()) {
-        diag_handler.err(&format!("failed to write asm file {}", e));
+    // If this is a regular module, write it to a file. For 'metadata' and
+    // 'allocator' modules `asm` is always `None`. `Metadata`/`allocator`
+    // modules are ignored for now. We don't crash when compiling
+    // `metadata`/`allocator` modules, because for each `regular` module, there
+    // is a `metadata` module that needs to be compiled.
+    if let Some(ref asm) = module.asm {
+        if let Err(e) = fs::write(path, asm) {
+            diag_handler.err(&format!("failed to write asm file {}", e));
+        }
     }
 }
 
@@ -37,24 +44,26 @@ pub unsafe fn codegen(
     config: &ModuleConfig,
     timeline: &mut Timeline
 ) -> Result<CompiledModule, FatalError> {
-    // no_integrated_as has to be true in order for the IronOx backend to work.
-    if !config.no_integrated_as {
-        bug!("IronOx does not have an integrated assembler!");
-    }
     let module_name = Some(&module.name[..]);
     // The path to the assembly file in which to write the module.
     let asm_path =
         cgcx.output_filenames.temp_path(OutputType::Assembly, module_name);
     write_module(&module.module_llvm, &asm_path, diag_handler);
     // The path to the object file in which to assemble the module.
-    let obj_path = cgcx.output_filenames
-        .temp_path(OutputType::Object, module_name);
-    // Run the assembler to produce the object file from the assembly.
-    run_assembler(cgcx, diag_handler, &asm_path, &obj_path);
+    let mut obj_path = None;
+    // `no_integrated_as` must be explicitly set to 'true' for all 'regular'
+    // modules. For 'metadata' and 'allocator' modules, `no_integrated_as` is
+    // always set to `false`. `metadata` and `allocator` modules are not assembled.
+    if config.no_integrated_as {
+        obj_path = Some(
+            cgcx.output_filenames.temp_path(OutputType::Object, module_name));
+        // Run the assembler to produce the object file from the assembly.
+        run_assembler(cgcx, diag_handler, &asm_path, &obj_path.clone().unwrap());
+    }
     Ok(CompiledModule {
         name: module.name.clone(),
         kind: module.kind,
-        object: Some(obj_path),
+        object: obj_path,
         bytecode: None,
         bytecode_compressed: None,
     })

--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -146,6 +146,9 @@ impl ExtraBackendMethods for IronOxCodegenBackend {
 pub struct ModuleIronOx {
     /// The functions defined in this module
     pub functions: Vec<IronOxFunction>,
+    /// The x86-64 program which corresponds to the module. This field is only
+    /// initialised after the code emitter processes the module.
+    pub asm: Option<String>,
 }
 
 impl ModuleIronOx {
@@ -153,6 +156,7 @@ impl ModuleIronOx {
     pub fn new() -> ModuleIronOx {
         ModuleIronOx {
             functions: Default::default(),
+            asm: None,
         }
     }
 
@@ -169,10 +173,6 @@ impl ModuleIronOx {
         fn_type: Type) -> Value {
         self.functions.push(IronOxFunction::new(cx, name, fn_type));
         Value::Function(self.functions.len() - 1)
-    }
-
-    pub fn asm(&self) -> String {
-        "nop".to_string()
     }
 }
 


### PR DESCRIPTION
There are 3 types of modules: `regular`, `metadata`, and `allocator`. 

For `regular` modules (the ones that contain the IR), `no_integrated_as` can be set by passing `no-integrated-as` to `rustc`. `no_integrated_as` is always false for `metadata` and `allocator` modules (as far as I know, they don't actually require an assembler anyway). Still, `codegen` is called for every module, including `metadata` and `allocator` ones. `run_assembler` should only be run on `regular` modules for which `no_integrated_as = true` (because `run_assembler` runs the GNU assembler, as opposed to the 'internal' one). I had to make these changes, because the compiler was panicking for `metadata` and `allocator` modules (at `bug!`).



