### PR TITLE
Implement `val_ty` and `ptr_to_ironox_type`.

### DIFF
--- a/src/librustc_codegen_ironox/abi.rs
+++ b/src/librustc_codegen_ironox/abi.rs
@@ -11,7 +11,7 @@
 use builder::Builder;
 use context::CodegenCx;
 use value::Value;
-use type_::Type;
+use type_::{LLType, Type};
 use type_of::LayoutIronOxExt;
 
 use libc::c_uint;
@@ -86,7 +86,10 @@ impl ArgTypeMethods<'tcx> for Builder<'a, 'll, 'tcx> {
 pub trait FnTypeExt<'tcx> {
     fn new(cx: &CodegenCx<'_, 'tcx>, sig: ty::FnSig<'tcx>,
            extra_args: &[Ty<'tcx>]) -> Self;
+    /// Return the IronOx `Type` that is equivalent to this type.
     fn ironox_type(&self, cx: &CodegenCx<'a, 'tcx>) -> Type;
+    /// Return the IronOx `Type` that is equivalent to this pointer type.
+    fn ptr_to_ironox_type(&self, cx: &CodegenCx<'a, 'tcx>) -> Type;
 }
 
 impl FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
@@ -166,6 +169,11 @@ impl FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
         } else {
             cx.type_func(&arg_tys, ret_ty)
         }
+    }
+
+    fn ptr_to_ironox_type(&self, cx: &CodegenCx<'a, 'tcx>) -> Type {
+        let fn_ty = self.ironox_type(cx);
+        cx.add_type(LLType::PtrTo { pointee: fn_ty })
     }
 }
 

--- a/src/librustc_codegen_ironox/ir/function.rs
+++ b/src/librustc_codegen_ironox/ir/function.rs
@@ -26,7 +26,7 @@ pub struct IronOxFunction {
     /// The parameters of the function.
     pub params: Vec<Value>,
     /// The return type of the function.
-    pub ret: Value,
+    pub ret: Type,
 }
 
 impl IronOxFunction {
@@ -36,11 +36,11 @@ impl IronOxFunction {
         fn_type: Type) -> IronOxFunction {
         match cx.types.borrow()[fn_type] {
             LLType::FnType { ref args, ref ret } => {
-                let ret = Value::Param(*ret);
                 let mut params = Vec::with_capacity(args.len());
                 for (index, arg_ty) in args.iter().enumerate() {
-                    params.push(Value::Param(*arg_ty));
+                    params.push(Value::Param(index, *arg_ty));
                 }
+                let ret = *ret;
                 IronOxFunction {
                     name: name.to_string(),
                     ironox_type: fn_type,

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -7,13 +7,18 @@
 // except according to those terms.
 
 use std::hash::{Hash, Hasher};
+use context::CodegenCx;
 use type_::Type;
+use super::ModuleIronOx;
+
+use rustc::ty::layout::Align;
+use rustc_codegen_ssa::traits::BaseTypeMethods;
 
 /// The unique identifier of an IronOx value.
 ///
 /// Each enum variant has one or more indices that can be used to retrieve the
 /// value from the context.
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Value {
     /// The index of an `IronOxFunction` function in the module.
     Function(usize),
@@ -28,22 +33,48 @@ pub enum Value {
     ConstInt(usize),
     /// The index of an `IronOxStruct` in the `structs` vec from `ModuleIronOx`.
     ConstStruct(usize),
-    /// The parameter of an `IronOxFunction`. This is just a wrapper around a `Type`.
-    Param(Type),
+    /// The parameter of an `IronOxFunction`. This is just a wrapper around a
+    /// `Type`. A parameter is an (index, type) pair, where 'index' is the
+    /// index of the parameter in the list of parameters of the function.
+    Param(usize, Type),
+    /// An instruction: (functiton index, basic block index, instruction index).
+    Instruction(usize, usize, usize),
     /// A placeholder for unimplemented Values. This variant will be removed.
     None,
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+/// An IronOx instruction.
+#[derive(PartialEq, Debug, Eq, Hash)]
 pub enum Instruction {
-    // FIXME: implement
+    /// Call(fn_idx, args). Emit a call to the function found at index `fn_idx`
+    /// in the `functions` vector of the module.
+    Call(usize, Vec<Value>),
+    /// Allocate space on the stack for a variable of a particular type and
+    /// alignment.
+    Alloca(String, Type, Align),
+    /// Cast a value to a type.
+    Cast(Value, Type),
+    /// Add two values and return the result.
+    Add(Value, Value),
+    /// Currently serves as a no-op. This variant will be removed.
     None,
 }
 
-impl Eq for Value {}
-
-impl Hash for Value {
-    fn hash<H: Hasher>(&self, hasher: &mut H) {
-        (self as *const Self).hash(hasher);
+impl Instruction {
+    /// Return the `Type` of the value that would result from evaluating this
+    /// instruction.
+    pub fn val_ty(&self, cx: &CodegenCx, module: &ModuleIronOx) -> Type {
+        match *self {
+            Instruction::Alloca(_, ty, _) => ty,
+            Instruction::Cast(_, ty) => ty,
+            Instruction::Add(v1, v2) => {
+                let ty1 = cx.val_ty(v1);
+                let ty2 = cx.val_ty(v2);
+                assert_eq!(ty1, ty2);
+                ty1
+            },
+            Instruction::Call(fn_idx, _) => cx.module.borrow().functions[fn_idx].ret,
+            Instruction::None => bug!("None does not have a type"),
+        }
     }
 }


### PR DESCRIPTION
This adds several new `Type`s, `Value`s (`Param`, `Instruction`), and `Instruction`s (`Call`, `Alloca`, `Cast`, `Add`).

* `val_ty` returns the `Type` of a `Value`.
* `ptr_to_ironox_type` (implemented for `FnType`s) returns a `Type` that represents a pointer to a function

