### PR TITLE
Store the compilation result in the module.

### DIFF
--- a/src/librustc_codegen_ironox/lib.rs
+++ b/src/librustc_codegen_ironox/lib.rs
@@ -87,6 +87,7 @@ mod type_of;
 mod metadata;
 mod mono_item;
 mod value;
+mod x86_asm_printer;
 
 use context::CodegenCx;
 use type_::Type;

--- a/src/librustc_codegen_ironox/type_.rs
+++ b/src/librustc_codegen_ironox/type_.rs
@@ -247,26 +247,16 @@ impl BaseTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn val_ty(&self, v: Value) -> Type {
         let module = &self.module.borrow();
         match v {
-            Value::ConstUint(const_idx) => {
-                self.u_consts.borrow()[const_idx].ty
-            },
-            Value::ConstInt(const_idx) => {
-                self.i_consts.borrow()[const_idx].ty
-            },
-            Value::Param(_, ty) => {
-                ty
-            },
+            Value::ConstUint(const_idx) => self.u_consts.borrow()[const_idx].ty,
+            Value::ConstInt(const_idx) => self.i_consts.borrow()[const_idx].ty,
+            Value::Param(_, ty) => ty,
+            Value::Function(fn_idx) => module.functions[fn_idx].ironox_type,
             Value::Instruction(fn_idx, bb_idx, inst_idx) => {
-                let inst =
-                    &module.functions[fn_idx].basic_blocks[bb_idx].instrs[inst_idx];
+                let inst = &module
+                    .functions[fn_idx].basic_blocks[bb_idx].instrs[inst_idx];
                 inst.val_ty(self, module)
             },
-            Value::Function(fn_idx) => {
-                module.functions[fn_idx].ironox_type
-            }
-            _ => {
-                unimplemented!("Type of {:?}", v);
-            }
+            _ => unimplemented!("Type of {:?}", v),
         }
     }
 

--- a/src/librustc_codegen_ironox/value.rs
+++ b/src/librustc_codegen_ironox/value.rs
@@ -68,10 +68,9 @@ impl Instruction {
             Instruction::Alloca(_, ty, _) => ty,
             Instruction::Cast(_, ty) => ty,
             Instruction::Add(v1, v2) => {
-                let ty1 = cx.val_ty(v1);
-                let ty2 = cx.val_ty(v2);
-                assert_eq!(ty1, ty2);
-                ty1
+                let ty = cx.val_ty(v1);
+                assert_eq!(ty, cx.val_ty(v2));
+                ty
             },
             Instruction::Call(fn_idx, _) => cx.module.borrow().functions[fn_idx].ret,
             Instruction::None => bug!("None does not have a type"),

--- a/src/librustc_codegen_ironox/x86_asm_printer.rs
+++ b/src/librustc_codegen_ironox/x86_asm_printer.rs
@@ -1,0 +1,54 @@
+use super::ModuleIronOx;
+
+use context::CodegenCx;
+use value::{Value, Instruction};
+
+use rustc::mir::mono::Stats;
+use rustc::util::nodemap::FxHashMap;
+use rustc_codegen_ssa::traits::MiscMethods;
+use std::cell::{Cell, RefCell};
+
+/// The result of evaluating an `Instruction`.
+#[derive(Debug)]
+pub struct InstrAsm {
+    /// The sequence of assembly instructions the instruction is compiled to.
+    asm: String,
+    /// The register/memory address that contains the result of the instruction.
+    result: String,
+}
+
+/// A module that contains the context for generating machine instructions from
+/// a `ModuleIronOx`.
+pub struct ModuleAsm<'ll, 'tcx> {
+    /// The codegen context, which also contains the `ModuleIronOx` to be compiled.
+    cx: CodegenCx<'ll, 'tcx>,
+    /// A mapping from high-level instructions to the assembly they compile to.
+    /// If the same instruction is used in two different expressions, it is
+    /// often enough to retrieve its result from this mapping (it does not always
+    /// have to be recompiled).
+    compiled_insts: RefCell<FxHashMap<Value, InstrAsm>>,
+    /// A mapping from function parameters to their location on the stack.
+    /// Currently, parameters are always pushed to and retrieved from the stack.
+    compiled_params: RefCell<FxHashMap<Value, InstrAsm>>,
+}
+
+impl ModuleAsm<'ll, 'tcx> {
+    pub fn new(cx: CodegenCx<'ll, 'tcx>) -> ModuleAsm<'ll, 'tcx> {
+        ModuleAsm {
+            cx,
+            compiled_insts: Default::default(),
+            compiled_params: Default::default(),
+            stack_size: Default::default(),
+        }
+    }
+
+    /// Return the x86-64 instructions that correspond to this module.
+    pub fn compile(&mut self) -> String {
+        unimplemented!("compile");
+    }
+}
+
+pub fn compile(mut module: ModuleAsm) -> (Stats, String) {
+    let asm = module.compile();
+    (module.cx.consume_stats().into_inner(), asm)
+}


### PR DESCRIPTION
This PR adds the `x86_64_asm_printer`, which emits x86-64 instructions for the module stored in the `CodegenCx`.

After compiling the `ModuleIronOx`, the string which contains the resulting assembly instructions is stored in the module itself:

```rust
ironox_module.asm = Some(asm);
```

This is necessary because, when writing the assembly file, the only information available is whatever is stored in the `Module` of the `CodegenCx`: https://github.com/gabi-250/rust/blob/master/src/librustc_codegen_ironox/lib.rs#L199. For this backend, the `Module` is `ModuleIronOx`. The `CodegenCx` is not available when writing the assembly file, so the assembly code has to be emitted  in `compile_codegen_unit`. For this reason, the assembly has to be stored in the module as an `Option<String>`.

The code emitted by the backend is written to disk here: https://github.com/gabi-250/rust/blob/master/src/librustc_codegen_ironox/back/write.rs#L51